### PR TITLE
Add dark mode to the blog

### DIFF
--- a/source/assets/_theme.scss
+++ b/source/assets/_theme.scss
@@ -1,0 +1,28 @@
+// Theme variables — dark mode is driven by `data-theme="dark"|"light"` on <html>.
+// An inline script in layout.erb sets the attribute before first paint, falling
+// back to prefers-color-scheme. A footer toggle flips and persists via localStorage.
+
+:root,
+[data-theme='light'] {
+  --color-bg: #fffff8;
+  --color-text: #111;
+  --color-border: #ccc;
+  --color-muted: grey;
+  --color-selection: #b4d5fe;
+  --color-btn-text: white;
+  --color-btn-overlay: rgba(0, 0, 0, 0.1);
+}
+
+[data-theme='dark'] {
+  --color-bg: #1a1a1a;
+  --color-text: #e8e6d8;
+  --color-border: #444;
+  --color-muted: #888;
+  --color-selection: #2d4a7a;
+  --color-btn-text: var(--color-text);
+  --color-btn-overlay: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme='dark'] img {
+  filter: brightness(0.9) contrast(1.1);
+}

--- a/source/assets/all.css.scss
+++ b/source/assets/all.css.scss
@@ -1,2 +1,2 @@
 // include all of the CSS files as one single file
-@import 'normalize', 'tufte', 'syntax.css', 'share-buttons.css', 'danalol';
+@import 'theme', 'normalize', 'tufte', 'syntax.css', 'share-buttons.css', 'danalol';

--- a/source/assets/danalol.scss
+++ b/source/assets/danalol.scss
@@ -5,7 +5,7 @@
 }
 
 .heading li {
-  color: grey;
+  color: var(--color-muted);
   display: inline;
   font-size: 0.9em;
   margin-right: 0.5em;
@@ -75,6 +75,19 @@ aside.footer {
   margin-bottom: 1em;
 }
 
+button.theme-toggle {
+  background: none;
+  border: 0;
+  padding: 0 0.4em;
+  margin-left: 0.4em;
+  cursor: pointer;
+  font-size: 1em;
+  color: inherit;
+  opacity: 0.6;
+
+  &:hover { opacity: 1; }
+}
+
 .btn {
   position: relative;
   vertical-align: top;
@@ -82,10 +95,10 @@ aside.footer {
   height: 60px;
   padding: 0;
   font-size: 22px;
-  color: white;
+  color: var(--color-btn-text);
   text-align: center;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
-  background: rgba(0, 0, 0, 0.1);
+  background: var(--color-btn-overlay);
   border: 0;
   cursor: pointer;
 }

--- a/source/assets/syntax.css.scss.erb
+++ b/source/assets/syntax.css.scss.erb
@@ -1,3 +1,3 @@
-<%# this generates a syntax highlighting theme %>
-<%= Rouge::Themes::Base16::Solarized.render(:scope => '.highlight') %>
-
+<%# syntax highlighting themes — Solarized Light + Solarized Dark, scoped per-theme %>
+<%= Rouge::Themes::Base16::Solarized.render(:scope => '[data-theme="light"] .highlight') %>
+<%= Rouge::Themes::Base16::Solarized.mode(:dark).render(:scope => '[data-theme="dark"] .highlight') %>

--- a/source/assets/tufte.scss
+++ b/source/assets/tufte.scss
@@ -35,8 +35,8 @@ body { width: 87.5%;
        margin-right: auto;
        padding-left: 12.5%;
        font-family: et-book, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Georgia, serif;
-       background-color: #fffff8;
-       color: #111;
+       background-color: var(--color-bg);
+       color: var(--color-text);
        max-width: 1400px;
        counter-reset: sidenote-counter; }
 
@@ -64,7 +64,7 @@ hr { display: block;
      height: 1px;
      width: 55%;
      border: 0;
-     border-top: 1px solid #ccc;
+     border-top: 1px solid var(--color-border);
      margin: 1em 0;
      padding: 0; }
 
@@ -145,26 +145,13 @@ figcaption { float: right;
 
 figure.fullwidth figcaption { margin-right: 24%; }
 
-/* Links: replicate underline that clears descenders */
-a:link, a:visited { color: inherit; }
+/* Links: native underline with descender clearing (upstream tufte-css 2024-10) */
+a:link, a:visited { color: inherit;
+                    text-underline-offset: 0.1em;
+                    text-decoration-thickness: 0.05em; }
 
-a:link { text-decoration: none;
-         background: -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(#333, #333);
-         background: linear-gradient(#fffff8, #fffff8), linear-gradient(#fffff8, #fffff8), linear-gradient(#333, #333);
-         -webkit-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-         -moz-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-         background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
-         background-repeat: no-repeat, no-repeat, repeat-x;
-         text-shadow: 0.03em 0 #fffff8, -0.03em 0 #fffff8, 0 0.03em #fffff8, 0 -0.03em #fffff8, 0.06em 0 #fffff8, -0.06em 0 #fffff8, 0.09em 0 #fffff8, -0.09em 0 #fffff8, 0.12em 0 #fffff8, -0.12em 0 #fffff8, 0.15em 0 #fffff8, -0.15em 0 #fffff8;
-         background-position: 0% 93%, 100% 93%, 0% 93%; }
-
-@media screen and (-webkit-min-device-pixel-ratio: 0) { a:link { background-position-y: 87%, 87%, 87%; } }
-
-a:link::selection { text-shadow: 0.03em 0 #b4d5fe, -0.03em 0 #b4d5fe, 0 0.03em #b4d5fe, 0 -0.03em #b4d5fe, 0.06em 0 #b4d5fe, -0.06em 0 #b4d5fe, 0.09em 0 #b4d5fe, -0.09em 0 #b4d5fe, 0.12em 0 #b4d5fe, -0.12em 0 #b4d5fe, 0.15em 0 #b4d5fe, -0.15em 0 #b4d5fe;
-                    background: #b4d5fe; }
-
-a:link::-moz-selection { text-shadow: 0.03em 0 #b4d5fe, -0.03em 0 #b4d5fe, 0 0.03em #b4d5fe, 0 -0.03em #b4d5fe, 0.06em 0 #b4d5fe, -0.06em 0 #b4d5fe, 0.09em 0 #b4d5fe, -0.09em 0 #b4d5fe, 0.12em 0 #b4d5fe, -0.12em 0 #b4d5fe, 0.15em 0 #b4d5fe, -0.15em 0 #b4d5fe;
-                         background: #b4d5fe; }
+a:link::selection,
+a:link::-moz-selection { background: var(--color-selection); }
 
 /* Sidenotes, margin notes, figures, captions */
 img { max-width: 100%; }

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -24,10 +24,25 @@
       <%= page_title %>
     </title>
 
+    <%# Set data-theme on <html> before paint to avoid a flash of the wrong theme. %>
+    <%# Reads localStorage.theme; falls back to OS prefers-color-scheme. %>
+    <script>
+      (function () {
+        try {
+          var d = document.documentElement;
+          var saved = localStorage.getItem('theme');
+          var theme = saved || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+          d.setAttribute('data-theme', theme);
+          d.style.setProperty('color-scheme', theme);
+        } catch (e) {}
+      })();
+    </script>
+
     <style>
       <%# include bare minimum styling so it looks decent before the CSS loads %>
       <%# set background color and hide everything else %>
       body{ background-color: #fffff8; padding-left: 12.5% }
+      html[data-theme='dark'] body { background-color: #1a1a1a; }
       article, aside { display: none; }
     </style>
     <%= feed_tag :atom, "#{blog.options.prefix.to_s}/feed.xml", title: "Atom Feed" %>
@@ -66,6 +81,7 @@
     <aside class='footer'>
       © <%= link_to 'Dana', '/contact' %> <%= Date.today.year %>, unless noted otherwise.
       Big thanks to <%= link_to 'these people', '/thanks' %>.
+      <button type='button' class='theme-toggle' aria-label='Toggle dark mode' onclick="(function(){var d=document.documentElement;var next=d.getAttribute('data-theme')==='dark'?'light':'dark';d.setAttribute('data-theme',next);d.style.setProperty('color-scheme',next);try{localStorage.setItem('theme',next);}catch(e){}})()">🌓</button>
     </aside>
 
     <%# this stuff is Google's recommendation for faster page loading %>


### PR DESCRIPTION
## Summary

Adds dark mode to the blog (single commit: `Add dark mode to the blog`).

- Auto-detects via `prefers-color-scheme` on first load
- Footer toggle flips themes; choice persisted in `localStorage`
- No flash-of-wrong-theme — inline head script in `layout.erb` applies the chosen theme before paint
- Syntax highlighting swaps to Solarized Dark via Rouge `mode(:dark)`

Files touched: `source/assets/_theme.scss` (new), `all.css.scss`, `danalol.scss`, `syntax.css.scss.erb`, `tufte.scss`, `source/layout.erb`.

Reference Dana saved: tufte.css-based blog with a working dark-mode implementation (per [[blog-dark-mode]]).

## Test plan

- [ ] Cloudflare Pages preview URL loads
- [ ] Light mode unchanged from current site
- [ ] Toggle in footer flips theme; reload preserves choice
- [ ] No flash on hard reload with dark mode active
- [ ] Code blocks render Solarized Dark in dark mode
- [ ] Spot-check a few article pages (figures, sidenotes, code blocks)