### PR TITLE
Migrate staging deploy to Cloudflare Pages

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,16 +1,6 @@
 name: Testing
 on:
   pull_request:
-    paths:
-      - .github/workflows/testing.yaml
-      - Gemfile
-      - Gemfile.lock
-      - config.rb
-      - data/**
-      - helpers/**
-      - source/**
-  issue_comment:
-    types: [created]
 
 env:
   ENV: test
@@ -20,31 +10,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version-file: .tool-versions
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - run: echo $ENV
-    - name: Attempt to build the static site
+        bundler-cache: true
+    - name: Build the static site
       run: bundle exec middleman build --bail
-    - name: Push the static site to stage
-      if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/push')
+    - name: Deploy to Cloudflare Pages (staging)
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
-        STAGE_S3_BUCKET: ${{ secrets.STAGE_S3_BUCKET }}
-      run: aws s3 sync build $STAGE_S3_BUCKET/build/
-    - uses: actions/github-script@v4.0.2
-      name: comment-on-pr
-      if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/push') && ! failure()
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          github.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: "Deployed to stage!"
-          });
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      run: npx wrangler pages deploy build/ --project-name dana-lol-staging

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,65 @@
+# Taskfile for the dana.lol Middleman site.
+#
+# Cloudflare Pages is the new staging deploy target (deploy:stage).
+# Production currently still serves from S3 — see :s3-suffixed tasks.
+# A follow-up will add a Cloudflare prod target (deploy:prod) once the
+# dana-lol Pages project is provisioned in terraform/prod-1/.
+
+version: '3'
+
+tasks:
+  build:
+    desc: Build the static site with full image optimization
+    cmds:
+      - bundle exec middleman build --bail
+
+  build:fast:
+    desc: Build without image optimization (faster, suitable for staging)
+    env:
+      ENV: test
+    cmds:
+      - bundle exec middleman build --bail
+
+  deploy:stage:
+    desc: Deploy build/ to Cloudflare Pages staging (dana-lol-staging)
+    cmds:
+      - npx wrangler pages deploy build/ --project-name dana-lol-staging
+
+  release:stage:
+    desc: Build (fast) and deploy to Cloudflare Pages staging
+    cmds:
+      - task: build:fast
+      - task: deploy:stage
+
+  # --- Legacy S3 paths ------------------------------------------------------
+  # Staging S3 retained as a fallback in case the Cloudflare Pages staging
+  # path needs to be rolled back. Prod S3 is the current production target
+  # for www.dana.lol (no Cloudflare prod project exists yet).
+
+  deploy:stage:s3:
+    desc: (fallback) Push build/ to staging S3 (set STAGE_S3_BUCKET and STAGE_CLOUDFRONT_DISTRIBUTION_ID)
+    env:
+      STATIC_SITE_BUCKET: $STAGE_S3_BUCKET
+      STATIC_SITE_CLOUDFRONT: $STAGE_CLOUDFRONT_DISTRIBUTION_ID
+    cmds:
+      - bundle exec s3_website push --site build
+
+  deploy:prod:s3:
+    desc: Push build/ to prod S3 — current www.dana.lol target (set PROD_S3_BUCKET and PROD_CLOUDFRONT_DISTRIBUTION_ID)
+    env:
+      STATIC_SITE_BUCKET: $PROD_S3_BUCKET
+      STATIC_SITE_CLOUDFRONT: $PROD_CLOUDFRONT_DISTRIBUTION_ID
+    cmds:
+      - bundle exec s3_website push --site build
+
+  release:stage:s3:
+    desc: (fallback) Build (fast) and deploy to staging S3
+    cmds:
+      - task: build:fast
+      - task: deploy:stage:s3
+
+  release:prod:s3:
+    desc: Build (with image optimization) and deploy to prod S3 (current prod)
+    cmds:
+      - task: build
+      - task: deploy:prod:s3


### PR DESCRIPTION
## Summary

Wire up Cloudflare Pages as the new staging deploy target for the website.

- **Testing workflow** (PRs): replaces the legacy `/push`-comment-gated S3 sync with an automatic `wrangler pages deploy build/ --project-name dana-lol-staging` on every PR. Cloudflare Pages assigns a per-PR preview URL and the Pages bot comments it on the PR.
- **Taskfile.yml**: adds `deploy:stage` / `release:stage` targeting Cloudflare Pages staging — local and CI now share one deploy command. Existing S3 tasks renamed to `deploy:stage:s3` / `deploy:prod:s3` (etc.) and retained, since www.dana.lol still serves from S3 and we may need a fast rollback path while the Cloudflare migration matures.

Scope intentionally excludes production: we don't have a Cloudflare prod project yet (`dana-lol`), and that requires Terraform infra work (`terraform/prod-1/`) which is a separate task. So `release.yml` is untouched and there's no `deploy:prod` (CF) Taskfile entry.

## Test plan

- [x] CI: Testing workflow runs on this PR and turns green
- [ ] Cloudflare Pages bot comments a preview URL on this PR
- [ ] Preview URL loads — site renders, assets work

## Out of scope (follow-ups)

- Create `cloudflare_pages_project "dana-lol"` in `terraform/prod-1/`
- Wire up the `Release` workflow to deploy to that prod project on GitHub Release publish
- Route53 `www.dana.lol` CNAME flip from S3 → Cloudflare Pages
- Consider pointing `www.whalecore.com` at the staging Cloudflare endpoint (custom domain on `dana-lol-staging`)