### PR TITLE
ci: per-branch alias URLs for PR previews

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,4 +22,4 @@ jobs:
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      run: npx wrangler pages deploy build/ --project-name dana-lol-staging
+      run: npx wrangler pages deploy build/ --project-name dana-lol-staging --branch ${{ github.head_ref }}


### PR DESCRIPTION
## Summary

One-line fix: pass `--branch ${{ github.head_ref }}` to `wrangler pages deploy` in `testing.yml`.

Before: every PR's preview shared `head.dana-lol-staging.pages.dev` as its alias, so the latest PR-deploy clobbered all the others. Per-deploy hash URLs (`1f030db3.dana-lol-staging.pages.dev`) still worked, but they're not nice to share or remember.

After: each PR gets a stable, readable alias at `<branch>.dana-lol-staging.pages.dev`. Re-pushing to the branch updates the same URL.

## Self-test

This PR is itself the test. Once CI runs, the preview alias should be `pages-per-branch-alias.dana-lol-staging.pages.dev` instead of `head.dana-lol-staging.pages.dev`.