### PR TITLE
ci: bump stale action versions in linting & update-pr workflows

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,9 +6,9 @@ jobs:
     name: misspell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: misspell
-        uses: reviewdog/action-misspell@v1.23
+        uses: reviewdog/action-misspell@v1
         with:
           github_token: ${{ secrets.github_token }}
           locale: "US"

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.CI_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- `actions/checkout` v2 → v4 in `linting.yml` and `update-pr.yml` — matches the v4 already used in `testing.yml`, `auto-tag.yml`, `release.yml`
- `reviewdog/action-misspell` v1.23 → v1 — drop the pinned patch in favor of the floating major tag, matching the convention elsewhere (`anothrNick/github-tag-action@1`, `ruby/setup-ruby@v1`)

`ankitvgupta/pr-updater@v1.4.0` left as-is — v1.4.0 is the latest upstream tag.

Same playbook as tripbot#397.

## Test plan
- [ ] Linting workflow runs on this PR with the bumped action versions
- [ ] Update-PR workflow can be exercised by commenting `/update` (covered post-merge on a future PR)