### PR TITLE
ci: add super-linter workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
-
+<!-- markdownlint-disable -->
 
 ---
-<!-- markdownlint-disable -->
 <details>
 <summary>Commands and options</summary>
 <br />

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,43 @@
+---
+name: Super Linter
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Run Linters
+    runs-on: ubuntu-latest
+
+    steps:
+      # fetch-depth: 0 is required by super-linter v6+: it diffs against
+      # the default branch (master) to figure out which files changed,
+      # which means master has to be present in the local checkout.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: run-linters
+        uses: super-linter/super-linter@v8.6.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # don't post a "Super-linter summary" comment on every PR run
+          # (the Actions step summary tab still gets the same content)
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
+          # disabled until we go through and fix the issues
+          VALIDATE_JSCPD: false
+          VALIDATE_ENV: false
+          # disabled until we can resolve their issues
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_CHECKOV: false
+          VALIDATE_GITHUB_ACTIONS: false
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          VALIDATE_JSON_PRETTIER: false
+          VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_SHELL_SHFMT: false
+          VALIDATE_SPELL_CODESPELL: false
+          VALIDATE_TRIVY: false
+          VALIDATE_YAML_PRETTIER: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -29,6 +29,20 @@ jobs:
           # disabled until we go through and fix the issues
           VALIDATE_JSCPD: false
           VALIDATE_ENV: false
+          # disabled — many SCSS modernization issues across source/assets/
+          # (color-function-notation, alpha-value-notation, vendor prefixes,
+          # length-zero-no-unit). Fix is non-trivial; revisit later.
+          VALIDATE_CSS: false
+          VALIDATE_CSS_PRETTIER: false
+          # disabled — needs a .rubocop.yml + bulk auto-fixes for
+          # frozen_string_literal comments and single→double quotes.
+          # Worth a dedicated PR.
+          VALIDATE_RUBY: false
+          # disabled — false-positive: cfn-lint emits a Pydantic/Python 3.14
+          # compat warning to stderr, which super-linter treats as a failure.
+          # The repo has no CFN templates today (legacy CFN samples in README
+          # only).
+          VALIDATE_CLOUDFORMATION: false
           # disabled until we can resolve their issues
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_CHECKOV: false

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Live site available here: [https://www.dana.lol](http://www.dana.lol)
 If you want you can read these two articles about how the site works: [part 1](https://www.dana.lol/2017/10/01/how-this-site-works) and [part 2](https://www.dana.lol/2017/10/12/how-this-site-works-p-2).
 
 
-### Contact Form
+## Contact Form
 
 The site is designed to be static, but there is a small app that runs [the contact page](https://www.dana.lol/contact). You can view the code that runs the contact page in the [`danalol-contact-form` project](https://github.com/dmerrick/danalol-contact-form).
 
 
-### Technical Infrastructure
+## Technical Infrastructure
 
 To build out the infrastructure required to run this site, you can use the CloudFormation templates found in `cloudformation/`
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# A Dana Life website
+
 [![Version](https://img.shields.io/github/v/release/dmerrick/website?sort=semver&include_prereleases)](https://github.com/dmerrick/website/releases)
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fdmerrick%2Fwebsite%2Fbadge&style=flat)](https://actions-badge.atrox.dev/dmerrick/website/goto)
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
@@ -17,7 +19,7 @@ The site is designed to be static, but there is a small app that runs [the conta
 To build out the infrastructure required to run this site, you can use the CloudFormation templates found in `cloudformation/`
 
 You will need domain name (like `example.com`), a blog domain name (like `www.example.com`), and an AWS ACM Certificate ARN string.
-```
+```sh
 # create the hosted zone in Route53
 aws cloudformation create-stack \
   --stack-name <<ROUTE53 STACK NAME>> \

--- a/source/assets/share-buttons.css
+++ b/source/assets/share-buttons.css
@@ -14,7 +14,6 @@ ul.share-buttons img{
 
 ul.share-buttons .sr-only{
   position: absolute;
-  clip: rect(1px 1px 1px 1px);
   clip: rect(1px, 1px, 1px, 1px);
   padding: 0;
   border: 0;


### PR DESCRIPTION
## Summary
- Add `.github/workflows/super-linter.yml` modeled on the tripbot setup (super-linter@v8.6.0, full-history checkout, PR summary comment disabled)
- Disable list trimmed of tripbot-specific entries (Go, Kubernetes) that don't apply here

First run will probably surface additional validators worth disabling — Ruby (no `.rubocop.yml`), Markdown (lots of blog posts), and HTML in ERB templates are likely candidates. Plan is to add disables in follow-up commits on this branch as failures appear, then merge once it's green.

## Test plan
- [ ] Super-linter runs against this PR
- [ ] Triage the failures and add `VALIDATE_*: false` lines for whichever validators are too noisy to adopt cold
- [ ] Workflow ends green before merging