### PR TITLE
Add Cloudflare Pages _redirects file

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -6,6 +6,15 @@
 # Include .well-known directory (Middleman ignores dot-directories by default)
 page '/.well-known/*', layout: false
 
+# Cloudflare Pages reads /_redirects at the build root for 301/302 rules.
+# Middleman skips files starting with "_" (treats them as partials), so
+# we copy source/_redirects to build/_redirects after each build.
+after_build do |builder|
+  src = File.join(builder.app.root, 'source', '_redirects')
+  dst = File.join(builder.app.root, builder.app.config[:build_dir], '_redirects')
+  FileUtils.cp(src, dst) if File.exist?(src)
+end
+
 # Per-page layout changes:
 #
 # With no layout

--- a/source/_redirects
+++ b/source/_redirects
@@ -1,0 +1,22 @@
+# Cloudflare Pages redirects.
+# Translated 1:1 from s3_website.yml's `redirects:` block — those S3
+# server-side redirects don't apply on Cloudflare Pages, so we re-declare
+# them here. Keep this in sync with s3_website.yml until prod also runs
+# on Cloudflare Pages and the S3 deploy path is retired.
+
+# Convenience short URLs
+/radio          /2017/10/11/san-francisco-emergency-radio-setup/             301
+/fb             https://www.facebook.com/adanalifeblog                       301
+/facebook       https://www.facebook.com/adanalifeblog                       301
+/youtube        https://www.youtube.com/channel/UC8Q7uFC1Xyr2ZnTWOk9Aizg     301
+/instagram      https://instagram.com/adanalife_                             301
+/twitter        https://twitter.com/adanalife_                               301
+/twitch         https://twitch.tv/adanalife_                                 301
+/van-tour       https://youtu.be/_own6DuEpLc                                 301
+/survey         https://forms.gle/a52NamfEfCcSP7Vc9                          301
+
+# Renamed articles — keep old URLs working
+/2018/03/05/trip-recap-central-coast/    /2018/03/05/trip-report-central-coast/  301
+/2019/01/13/eleven-month-update/         /2019/01/13/post-adventure-summary/     301
+/2017/10/01/how-this-site-works-p-2/     /2017/10/12/how-this-site-works-p-2/    301
+/2017/10/12/how-this-site-works-p-1/     /2017/10/01/how-this-site-works/        301


### PR DESCRIPTION
## Summary

- Translates the 13 redirects in `s3_website.yml`'s `redirects:` block 1:1 into a CF Pages `_redirects` file at `build/_redirects`.
- CF Pages doesn't read the s3_website config, so without this every short URL (`/youtube`, `/van-tour`, `/twitter`, `/fb`, etc.) and every renamed-article redirect 404s on whalecore.com.
- Middleman skips files starting with `_` (treats them as partials), so `config.rb` gets a small `after_build` hook that copies `source/_redirects` into `build/_redirects` on every build.
- The s3_website.yml block stays untouched so the prod S3 deploy keeps working until prod cuts over to Cloudflare Pages.

## Test plan

- [x] `ENV=test bundle exec middleman build --bail` succeeds; `build/_redirects` lands at the build root with the full redirect list
- [ ] On the PR preview URL, `curl -sI <preview>/youtube` returns `301` to the YouTube channel
- [ ] Same for `/van-tour`, `/twitter`, `/fb`
- [ ] `/2018/03/05/trip-recap-central-coast/` 301s to the current `trip-report-central-coast` URL
- [ ] Pages that aren't in the redirects list still load normally (no regression)