### PR TITLE
Release: CF Pages redirects + CI version bumps

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
-
+<!-- markdownlint-disable -->
 
 ---
-<!-- markdownlint-disable -->
 <details>
 <summary>Commands and options</summary>
 <br />

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,9 +6,9 @@ jobs:
     name: misspell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: misspell
-        uses: reviewdog/action-misspell@v1.23
+        uses: reviewdog/action-misspell@v1
         with:
           github_token: ${{ secrets.github_token }}
           locale: "US"

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,57 @@
+---
+name: Super Linter
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Run Linters
+    runs-on: ubuntu-latest
+
+    steps:
+      # fetch-depth: 0 is required by super-linter v6+: it diffs against
+      # the default branch (master) to figure out which files changed,
+      # which means master has to be present in the local checkout.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: run-linters
+        uses: super-linter/super-linter@v8.6.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # don't post a "Super-linter summary" comment on every PR run
+          # (the Actions step summary tab still gets the same content)
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
+          # disabled until we go through and fix the issues
+          VALIDATE_JSCPD: false
+          VALIDATE_ENV: false
+          # disabled — many SCSS modernization issues across source/assets/
+          # (color-function-notation, alpha-value-notation, vendor prefixes,
+          # length-zero-no-unit). Fix is non-trivial; revisit later.
+          VALIDATE_CSS: false
+          VALIDATE_CSS_PRETTIER: false
+          # disabled — needs a .rubocop.yml + bulk auto-fixes for
+          # frozen_string_literal comments and single→double quotes.
+          # Worth a dedicated PR.
+          VALIDATE_RUBY: false
+          # disabled — false-positive: cfn-lint emits a Pydantic/Python 3.14
+          # compat warning to stderr, which super-linter treats as a failure.
+          # The repo has no CFN templates today (legacy CFN samples in README
+          # only).
+          VALIDATE_CLOUDFORMATION: false
+          # disabled until we can resolve their issues
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_CHECKOV: false
+          VALIDATE_GITHUB_ACTIONS: false
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          VALIDATE_JSON_PRETTIER: false
+          VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_SHELL_SHFMT: false
+          VALIDATE_SPELL_CODESPELL: false
+          VALIDATE_TRIVY: false
+          VALIDATE_YAML_PRETTIER: false

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.CI_PERSONAL_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# A Dana Life website
+
 [![Version](https://img.shields.io/github/v/release/dmerrick/website?sort=semver&include_prereleases)](https://github.com/dmerrick/website/releases)
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fdmerrick%2Fwebsite%2Fbadge&style=flat)](https://actions-badge.atrox.dev/dmerrick/website/goto)
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
@@ -7,17 +9,17 @@ Live site available here: [https://www.dana.lol](http://www.dana.lol)
 If you want you can read these two articles about how the site works: [part 1](https://www.dana.lol/2017/10/01/how-this-site-works) and [part 2](https://www.dana.lol/2017/10/12/how-this-site-works-p-2).
 
 
-### Contact Form
+## Contact Form
 
 The site is designed to be static, but there is a small app that runs [the contact page](https://www.dana.lol/contact). You can view the code that runs the contact page in the [`danalol-contact-form` project](https://github.com/dmerrick/danalol-contact-form).
 
 
-### Technical Infrastructure
+## Technical Infrastructure
 
 To build out the infrastructure required to run this site, you can use the CloudFormation templates found in `cloudformation/`
 
 You will need domain name (like `example.com`), a blog domain name (like `www.example.com`), and an AWS ACM Certificate ARN string.
-```
+```sh
 # create the hosted zone in Route53
 aws cloudformation create-stack \
   --stack-name <<ROUTE53 STACK NAME>> \

--- a/config.rb
+++ b/config.rb
@@ -6,6 +6,15 @@
 # Include .well-known directory (Middleman ignores dot-directories by default)
 page '/.well-known/*', layout: false
 
+# Cloudflare Pages reads /_redirects at the build root for 301/302 rules.
+# Middleman skips files starting with "_" (treats them as partials), so
+# we copy source/_redirects to build/_redirects after each build.
+after_build do |builder|
+  src = File.join(builder.app.root, 'source', '_redirects')
+  dst = File.join(builder.app.root, builder.app.config[:build_dir], '_redirects')
+  FileUtils.cp(src, dst) if File.exist?(src)
+end
+
 # Per-page layout changes:
 #
 # With no layout

--- a/source/_redirects
+++ b/source/_redirects
@@ -1,0 +1,22 @@
+# Cloudflare Pages redirects.
+# Translated 1:1 from s3_website.yml's `redirects:` block — those S3
+# server-side redirects don't apply on Cloudflare Pages, so we re-declare
+# them here. Keep this in sync with s3_website.yml until prod also runs
+# on Cloudflare Pages and the S3 deploy path is retired.
+
+# Convenience short URLs
+/radio          /2017/10/11/san-francisco-emergency-radio-setup/             301
+/fb             https://www.facebook.com/adanalifeblog                       301
+/facebook       https://www.facebook.com/adanalifeblog                       301
+/youtube        https://www.youtube.com/channel/UC8Q7uFC1Xyr2ZnTWOk9Aizg     301
+/instagram      https://instagram.com/adanalife_                             301
+/twitter        https://twitter.com/adanalife_                               301
+/twitch         https://twitch.tv/adanalife_                                 301
+/van-tour       https://youtu.be/_own6DuEpLc                                 301
+/survey         https://forms.gle/a52NamfEfCcSP7Vc9                          301
+
+# Renamed articles — keep old URLs working
+/2018/03/05/trip-recap-central-coast/    /2018/03/05/trip-report-central-coast/  301
+/2019/01/13/eleven-month-update/         /2019/01/13/post-adventure-summary/     301
+/2017/10/01/how-this-site-works-p-2/     /2017/10/12/how-this-site-works-p-2/    301
+/2017/10/12/how-this-site-works-p-1/     /2017/10/01/how-this-site-works/        301

--- a/source/assets/share-buttons.css
+++ b/source/assets/share-buttons.css
@@ -14,7 +14,6 @@ ul.share-buttons img{
 
 ul.share-buttons .sr-only{
   position: absolute;
-  clip: rect(1px 1px 1px 1px);
   clip: rect(1px, 1px, 1px, 1px);
   padding: 0;
   border: 0;


### PR DESCRIPTION
Promotes develop to master so the auto-tag + release deploy push these changes to whalecore.com.

## Included

- **#185** Add Cloudflare Pages `_redirects` file — restores the 13 redirects from `s3_website.yml` (`/youtube`, `/van-tour`, `/twitter`, `/fb`, `/facebook`, `/instagram`, `/twitch`, `/radio`, `/survey`, plus 4 renamed-article redirects). Verified on the per-branch preview alias.
- **#184** ci: add super-linter workflow — adds the Super Linter check to PRs (Markdown, YAML, XML, BIOME, GITLEAKS, PRE_COMMIT, etc.).
- **#183** ci: bump stale action versions in linting & update-pr workflows.

## Test plan

- [ ] After merge: `auto-tag.yml` cuts a new tag, `release.yml` deploys to whalecore.com
- [ ] `curl -sI https://www.whalecore.com/youtube` returns 301 to the YouTube channel
- [ ] Same for `/van-tour`, `/twitter`, `/fb`, etc.
- [ ] Lychee re-scan of whalecore.com shows the redirect 404s cleared