### PR TITLE
ci(release): pin wrangler deploy to --branch master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,10 @@ jobs:
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      run: npx wrangler pages deploy build/ --project-name dana-lol-staging
+      # Tag pushes have detached HEAD; without --branch, wrangler defaults
+      # to the "head" alias and the deploy never reaches the production
+      # alias serving whalecore.com. Pin to master so releases promote.
+      run: npx wrangler pages deploy build/ --project-name dana-lol-staging --branch master
 
     - name: Post Discord notification
       env:


### PR DESCRIPTION
## Summary

Releases since the CF Pages migration have been silently *not* promoting to whalecore.com. The deploy step in \`release.yml\` calls \`wrangler pages deploy\` without \`--branch\`. On tag pushes git is in detached HEAD, so wrangler can't infer a branch and falls back to the \`head\` alias — which isn't the alias serving the production custom domain.

Visible symptom: whalecore.com is missing dark mode (#176, shipped in v1.2.0) and the \`_redirects\` file (#185, shipped in v1.2.1). Both are present in the actual deploy bundles — they just never reach the production alias.

This pins \`--branch master\` so each release lands on the master alias.

## Follow-up

A vault TODO is filed to confirm the Pages \"Production branch\" in the dashboard is set to \`master\`. If it's still \`main\` (CF Pages default), this fix alone won't promote.

## Test plan

- [ ] After merge → develop → master → tag → release: \`curl -sI https://www.whalecore.com/youtube\` returns 301
- [ ] whalecore.com homepage shows the dark-mode 🌓 toggle in the footer