### PR TITLE
Release: pin wrangler deploy to --branch master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,10 @@ jobs:
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      run: npx wrangler pages deploy build/ --project-name dana-lol-staging
+      # Tag pushes have detached HEAD; without --branch, wrangler defaults
+      # to the "head" alias and the deploy never reaches the production
+      # alias serving whalecore.com. Pin to master so releases promote.
+      run: npx wrangler pages deploy build/ --project-name dana-lol-staging --branch master
 
     - name: Post Discord notification
       env:


### PR DESCRIPTION
Promotes develop to master so auto-tag + release.yml deploys with the --branch master fix.

## Included

- **#187** ci(release): pin wrangler deploy to --branch master — releases since the CF Pages migration have been silently landing on the \`head\` alias instead of the production alias serving whalecore.com. This pins \`--branch master\` so each release lands where the production custom domain is wired.

## Test plan

- [ ] Auto-tag cuts v1.2.2, release.yml runs with --branch master
- [ ] \`curl -sI https://www.whalecore.com/youtube\` returns 301 (the redirects from v1.2.1 finally reach whalecore.com)
- [ ] whalecore.com homepage shows the 🌓 dark-mode toggle (also catches up from v1.2.0)