### PR TITLE
fix: photo-proxy .gif support + relative internal links

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -59,7 +59,7 @@ class PhotoLandingPages
     new_proxies = []
 
     resources.each do |r|
-      next unless r.path =~ /\.(jpg|png)$/i
+      next unless r.path =~ /\.(jpg|png|gif)$/i
       next if r.path =~ %r{^assets/} || r.path =~ /ogp-image/
 
       ext = File.extname(r.destination_path)

--- a/source/2018-02-21-trip-report-big-sur.html.md.erb
+++ b/source/2018-02-21-trip-report-big-sur.html.md.erb
@@ -40,7 +40,7 @@ Also if you're reading this on mobile, make sure to tap the "⊕" icons when you
 
 ### <a name='overview'>Overview</a>
 
-After spending [the first night of my van adventure](https://www.dana.lol/2018/02/14/and-we-re-off/) in Santa Cruz, I drove down Highway 1 to spend my first week in [Big Sur](https://en.wikipedia.org/wiki/Big_Sur).
+After spending [the first night of my van adventure](/2018/02/14/and-we-re-off/) in Santa Cruz, I drove down Highway 1 to spend my first week in [Big Sur](https://en.wikipedia.org/wiki/Big_Sur).
 Big Sur is a dramatic meeting of land and sea... a place where you can find stirring beaches, rugged mountains, serene redwood grottos, and steep rocky islets, all within view of one another.
 It is a magical place that has been left largely unmolested by humankind, and it was a spectacular way to start a trip across America.
 

--- a/source/2018-09-26-map-adventure-so-far-v2.html.md.erb
+++ b/source/2018-09-26-map-adventure-so-far-v2.html.md.erb
@@ -14,7 +14,7 @@ ogp:
       height: 630
 ---
 
-Since everyone enjoyed [the last map of the adventure](https://dana.lol/2018/06/30/map-adventure-so-far/), I've updated the map to reflect the journey thus far.
+Since everyone enjoyed [the last map of the adventure](/2018/06/30/map-adventure-so-far/), I've updated the map to reflect the journey thus far.
 When this map was created I was outside of Dallas, TX, having come from the East.
 
 <%= f "#{current_article.url}map.png", 'a map showing the journey so far' %>

--- a/source/2019-01-13-post-adventure-summary.html.md.erb
+++ b/source/2019-01-13-post-adventure-summary.html.md.erb
@@ -69,7 +69,7 @@ I recently created social media accounts on each of the major platforms, includi
 * [Facebook](https://www.facebook.com/adanalifeblog)
 * [Twitch](https://twitch.tv/adanalife_)
 * [Twitter](https://twitter.com/adanalife_)
-* [YouTube](https://dana.lol/youtube)
+* [YouTube](/youtube)
 
 
 And as always, thank you for reading!

--- a/source/contact.html.md.erb
+++ b/source/contact.html.md.erb
@@ -13,7 +13,7 @@ You can find me on the following sites and contact me through there.
  * [Twitter](https://twitter.com/adanalife_)
  * [Instagram](https://instagram.com/adanalife_)
  * [Twitch](https://twitch.tv/adanalife_)
- * [YouTube](https://dana.lol/youtube)
+ * [YouTube](/youtube)
  * [Keybase](https://keybase.io/adanalife)
  * [Github](https://github.com/adanalife)
  * ...or just email me using the old-school web form below


### PR DESCRIPTION
## Summary

Two atomic fixes from the post-v1.2.3 audit run against whalecore.com:

1. **`config.rb`** — photo landing page proxy regex now includes `.gif`. Previously only matched `.jpg`/`.png`, so `cycling-animation.gif` (the only `.gif` in source) had no landing page generated and the lightbox click 404'd.
2. **4 inline body links** converted from hardcoded `https://dana.lol/...` to relative paths. Two `/youtube` links 404'd on whalecore (redirect lives in `source/_redirects`, only honored by the domain serving the site). The other two only worked because dana.lol's old S3 build still serves the same content. Relative paths work on both whalecore today and dana.lol after cutover.

OGP frontmatter and Twitter/Facebook share URLs intentionally stay absolute — social media crawlers need fully-qualified URLs.

## Test plan

- [ ] Verify on `fix-gif-proxy-and-relative-internal-links.dana-lol-staging.pages.dev`:
  - [ ] `/2020/04/16/the-most-boring-stream-on-twitch/cycling-animation` → 200 + text/html
  - [ ] `/contact` body link to YouTube → relative `/youtube` (and resolves via `_redirects`)
  - [ ] `/2019/01/13/post-adventure-summary/` body link to YouTube → relative `/youtube`
  - [ ] `/2018/09/26/map-adventure-so-far-v2/` map link → relative
  - [ ] `/2018/02/21/trip-report-big-sur/` first-night-of-van link → relative
- [ ] No regression on existing photo landing pages (spot-check 2-3)