### PR TITLE
ci(testing): sticky PR comment with CF Pages preview URL

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,6 +2,10 @@ name: Testing
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   ENV: test
 
@@ -19,7 +23,19 @@ jobs:
     - name: Build the static site
       run: bundle exec middleman build --bail
     - name: Deploy to Cloudflare Pages (staging)
+      id: deploy
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      run: npx wrangler pages deploy build/ --project-name dana-lol-staging --branch ${{ github.head_ref }}
+      shell: bash
+      run: |
+        set -o pipefail
+        npx wrangler pages deploy build/ --project-name dana-lol-staging --branch ${{ github.head_ref }} | tee wrangler.out
+        alias=$(grep "Deployment alias URL:" wrangler.out | grep -oE 'https://[^ ]+' | tail -1)
+        echo "alias=$alias" >> "$GITHUB_OUTPUT"
+    - name: Sticky preview URL comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: cf-preview
+        message: |
+          🔭 **Preview:** ${{ steps.deploy.outputs.alias }}


### PR DESCRIPTION
## Summary

Wrangler truncates the per-branch CF Pages preview alias to 28 chars (e.g. branch `fix-gif-proxy-and-relative-internal-links` → host `fix-gif-proxy-and-relative-i.dana-lol-staging.pages.dev`), so the URL isn't predictable from the branch name alone. Pinning it as a sticky comment via `marocchino/sticky-pull-request-comment` so it's one place to look on every PR, idempotently updated each push.

Adds `permissions: pull-requests: write` to the workflow so the comment action can post.

## Test plan

- [ ] On this PR's first run, a `🔭 Preview: https://...pages.dev` comment lands
- [ ] Comment URL responds 200 and serves the build for this branch
- [ ] On a follow-up push, the same comment is updated in place (no duplicate)