### PR TITLE
Pre-launch polish: footer Dana → /about, Twitch iframe title

### DIFF
--- a/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
+++ b/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
@@ -20,6 +20,7 @@ I'm really excited to announce a new project I've been working on:
 <% iframe_wrapper do %>
   <iframe
     src="https://player.twitch.tv/?channel=adanalife_&parent=dana.lol&parent=www.dana.lol&parent=staging.dana.lol&parent=develop.dana.lol&muted=true&autoplay=false"
+    title="Twitch live stream"
     height="378"
     width="620"
     frameborder="0"

--- a/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
+++ b/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
@@ -21,6 +21,7 @@ This was my experience the year I [lived in a van](/2017/10/25/i-got-a-van/).
 <% iframe_wrapper do %>
   <iframe
     src="https://player.twitch.tv/?channel=adanalife_&parent=dana.lol&parent=www.dana.lol&parent=staging.dana.lol&parent=develop.dana.lol&muted=true&autoplay=true"
+    title="Twitch live stream"
     height="378"
     width="620"
     frameborder="0"

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -79,7 +79,7 @@
     </article>
 
     <aside class='footer'>
-      © <%= link_to 'Dana', '/contact' %> <%= Date.today.year %>, unless noted otherwise.
+      © <%= link_to 'Dana', '/about' %> <%= Date.today.year %>, unless noted otherwise.
       Big thanks to <%= link_to 'these people', '/thanks' %>.
       <button type='button' class='theme-toggle' aria-label='Toggle dark mode' onclick="(function(){var d=document.documentElement;var next=d.getAttribute('data-theme')==='dark'?'light':'dark';d.setAttribute('data-theme',next);d.style.setProperty('color-scheme',next);try{localStorage.setItem('theme',next);}catch(e){}})()">🌓</button>
     </aside>


### PR DESCRIPTION
## Summary

Two small polish items from the pre-launch QA backlog:

1. **Footer "Dana" link → `/about`** (`source/layout.erb`). Was `/contact`; `/about` is a more sensible landing.
2. **Twitch iframe `title` attribute** added to the two articles with embedded Twitch players (`2018-08-20-jump-into-my-passenger-seat`, `2020-04-16-the-most-boring-stream-on-twitch`). Lighthouse a11y flag.

## Test plan

- [ ] Footer "Dana" link goes to `/about/` on the preview alias
- [ ] View source on the two Twitch articles → `<iframe ... title="Twitch live stream">`
- [ ] No regression on Twitch player loading