### PR TITLE
Release: post-QA polish + sticky preview CI #minor

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,6 +2,10 @@ name: Testing
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   ENV: test
 
@@ -19,7 +23,19 @@ jobs:
     - name: Build the static site
       run: bundle exec middleman build --bail
     - name: Deploy to Cloudflare Pages (staging)
+      id: deploy
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      run: npx wrangler pages deploy build/ --project-name dana-lol-staging --branch ${{ github.head_ref }}
+      shell: bash
+      run: |
+        set -o pipefail
+        npx wrangler pages deploy build/ --project-name dana-lol-staging --branch ${{ github.head_ref }} | tee wrangler.out
+        alias=$(grep "Deployment alias URL:" wrangler.out | grep -oE 'https://[^ ]+' | tail -1)
+        echo "alias=$alias" >> "$GITHUB_OUTPUT"
+    - name: Sticky preview URL comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: cf-preview
+        message: |
+          🔭 **Preview:** ${{ steps.deploy.outputs.alias }}

--- a/config.rb
+++ b/config.rb
@@ -35,29 +35,49 @@ page '/404.html', directory_index: false
 ignore "photo.html"
 ignore "photo.html.erb"
 
-# create a photo landing page for every image
-ready do
-  # Iterate over all .html.md.erb files to find associated images
-  sitemap.resources.select { |r| r.path.end_with?(".html") && !r.path.include?("photo.html") }.each do |page|
-    # Get the directory for the page
-    page_dir = File.dirname(page.path)
+# Generate a photo landing page (/photo.html) for every image, mounted at
+# the image's slug-without-extension. linked_image() in dana_lol_helpers
+# wraps every <img> in <a href="<slug>"> pointing here.
+#
+# Implemented as a single sitemap manipulator (rather than calling proxy
+# in a `ready do` loop): each proxy() call inside ready triggers a full
+# manipulator pipeline re-run, including middleman-images. With ~190
+# images the build went from ~2 minutes to ~10. Adding them as one
+# batch keeps the manipulator pipeline at one pass.
+#
+# Priority 90 runs after the blog plugin (default 50, sets URL-style
+# destination_paths for date-folder images) and before directory_indexes
+# (100, rewrites the .html proxy path into <slug>/index.html so CF Pages
+# serves it as text/html at the bare-slug URL).
+class PhotoLandingPages
+  def initialize(app)
+    @app = app
+  end
 
-    # Find all image files in this directory
-    Dir.glob("source/#{page_dir}/*.{jpg,png}").each do |image_path|
-      # Remove "source/" prefix for the relative image path
-      relative_path = image_path.sub(%r{^source/}, '')
+  def manipulate_resource_list(resources)
+    existing = resources.map(&:path).to_set
+    new_proxies = []
 
-      # Get the destination path without the extension
-      short_path = relative_path.sub(/#{File.extname(relative_path)}$/, '')
+    resources.each do |r|
+      next unless r.path =~ /\.(jpg|png)$/i
+      next if r.path =~ %r{^assets/} || r.path =~ /ogp-image/
 
-      # Avoid duplicate proxies
-      next if sitemap.find_resource_by_path(short_path)
+      ext = File.extname(r.destination_path)
+      short_path = r.destination_path.sub(/#{Regexp.escape(ext)}$/, '') + '.html'
+      next if existing.include?(short_path)
+      existing << short_path
 
-      # Create a proxy for the image
-      proxy short_path, "/photo.html", layout: 'layout', locals: { photo: sitemap.find_resource_by_path(relative_path) }, ignore: true
+      proxy = ::Middleman::Sitemap::ProxyResource.new(@app.sitemap, short_path, '/photo.html')
+      proxy.add_metadata(locals: { photo: r }, options: { layout: 'layout' })
+      new_proxies << proxy
     end
+
+    resources + new_proxies
   end
 end
+
+require 'set'
+sitemap.register_resource_list_manipulator(:photo_landing_pages, PhotoLandingPages.new(self), 90)
 
 # set the default URL
 set :url_root, @app.data.settings.site.url

--- a/config.rb
+++ b/config.rb
@@ -59,7 +59,7 @@ class PhotoLandingPages
     new_proxies = []
 
     resources.each do |r|
-      next unless r.path =~ /\.(jpg|png)$/i
+      next unless r.path =~ /\.(jpg|png|gif)$/i
       next if r.path =~ %r{^assets/} || r.path =~ /ogp-image/
 
       ext = File.extname(r.destination_path)

--- a/source/2018-02-21-trip-report-big-sur.html.md.erb
+++ b/source/2018-02-21-trip-report-big-sur.html.md.erb
@@ -40,7 +40,7 @@ Also if you're reading this on mobile, make sure to tap the "⊕" icons when you
 
 ### <a name='overview'>Overview</a>
 
-After spending [the first night of my van adventure](https://www.dana.lol/2018/02/14/and-we-re-off/) in Santa Cruz, I drove down Highway 1 to spend my first week in [Big Sur](https://en.wikipedia.org/wiki/Big_Sur).
+After spending [the first night of my van adventure](/2018/02/14/and-we-re-off/) in Santa Cruz, I drove down Highway 1 to spend my first week in [Big Sur](https://en.wikipedia.org/wiki/Big_Sur).
 Big Sur is a dramatic meeting of land and sea... a place where you can find stirring beaches, rugged mountains, serene redwood grottos, and steep rocky islets, all within view of one another.
 It is a magical place that has been left largely unmolested by humankind, and it was a spectacular way to start a trip across America.
 

--- a/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
+++ b/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
@@ -20,6 +20,7 @@ I'm really excited to announce a new project I've been working on:
 <% iframe_wrapper do %>
   <iframe
     src="https://player.twitch.tv/?channel=adanalife_&parent=dana.lol&parent=www.dana.lol&parent=staging.dana.lol&parent=develop.dana.lol&muted=true&autoplay=false"
+    title="Twitch live stream"
     height="378"
     width="620"
     frameborder="0"

--- a/source/2018-09-26-map-adventure-so-far-v2.html.md.erb
+++ b/source/2018-09-26-map-adventure-so-far-v2.html.md.erb
@@ -14,7 +14,7 @@ ogp:
       height: 630
 ---
 
-Since everyone enjoyed [the last map of the adventure](https://dana.lol/2018/06/30/map-adventure-so-far/), I've updated the map to reflect the journey thus far.
+Since everyone enjoyed [the last map of the adventure](/2018/06/30/map-adventure-so-far/), I've updated the map to reflect the journey thus far.
 When this map was created I was outside of Dallas, TX, having come from the East.
 
 <%= f "#{current_article.url}map.png", 'a map showing the journey so far' %>

--- a/source/2019-01-13-post-adventure-summary.html.md.erb
+++ b/source/2019-01-13-post-adventure-summary.html.md.erb
@@ -69,7 +69,7 @@ I recently created social media accounts on each of the major platforms, includi
 * [Facebook](https://www.facebook.com/adanalifeblog)
 * [Twitch](https://twitch.tv/adanalife_)
 * [Twitter](https://twitter.com/adanalife_)
-* [YouTube](https://dana.lol/youtube)
+* [YouTube](/youtube)
 
 
 And as always, thank you for reading!

--- a/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
+++ b/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
@@ -21,6 +21,7 @@ This was my experience the year I [lived in a van](/2017/10/25/i-got-a-van/).
 <% iframe_wrapper do %>
   <iframe
     src="https://player.twitch.tv/?channel=adanalife_&parent=dana.lol&parent=www.dana.lol&parent=staging.dana.lol&parent=develop.dana.lol&muted=true&autoplay=true"
+    title="Twitch live stream"
     height="378"
     width="620"
     frameborder="0"

--- a/source/contact.html.md.erb
+++ b/source/contact.html.md.erb
@@ -13,7 +13,7 @@ You can find me on the following sites and contact me through there.
  * [Twitter](https://twitter.com/adanalife_)
  * [Instagram](https://instagram.com/adanalife_)
  * [Twitch](https://twitch.tv/adanalife_)
- * [YouTube](https://dana.lol/youtube)
+ * [YouTube](/youtube)
  * [Keybase](https://keybase.io/adanalife)
  * [Github](https://github.com/adanalife)
  * ...or just email me using the old-school web form below

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -79,7 +79,7 @@
     </article>
 
     <aside class='footer'>
-      © <%= link_to 'Dana', '/contact' %> <%= Date.today.year %>, unless noted otherwise.
+      © <%= link_to 'Dana', '/about' %> <%= Date.today.year %>, unless noted otherwise.
       Big thanks to <%= link_to 'these people', '/thanks' %>.
       <button type='button' class='theme-toggle' aria-label='Toggle dark mode' onclick="(function(){var d=document.documentElement;var next=d.getAttribute('data-theme')==='dark'?'light':'dark';d.setAttribute('data-theme',next);d.style.setProperty('color-scheme',next);try{localStorage.setItem('theme',next);}catch(e){}})()">🌓</button>
     </aside>


### PR DESCRIPTION
## Summary

Bundles three PRs merged to develop since v1.2.3:

- **#191** — `.gif` photo-proxy support (restores `cycling-animation` landing page) + 4 hardcoded internal `dana.lol` links converted to relative paths
- **#192** — Testing workflow now posts the CF Pages preview URL as a sticky PR comment (no more squinting at wrangler logs to find the truncated alias)
- **#193** — Pre-launch polish: footer "Dana" link → `/about`, Twitch `<iframe title>` for a11y

## Audit improvement (vs 2026-05-06 pre-launch baseline)

Verified on `develop.dana-lol-staging.pages.dev`:

| Metric | 2026-05-06 baseline | 2026-05-07 post-v1.2.3 | Now (this release) |
|---|---|---|---|
| lychee errors | 176 | 17 | **7** |
| Playwright pages w/ issues | 11/96 | — | **10/96** |

The remaining 7 lychee errors and 10 Playwright issues are all pre-existing items in `vault/website/TODO.md` (Twitch CSP on preview host, /prime page, contact-form 503, external dead links, headless-Chromium GA aborts). **Zero new errors introduced.**

Spot-checks on the preview, all green:
- `cycling-animation.gif` landing → 200 + text/html
- 4 relative internal links rendering as `/youtube` / `/2018/...`
- Footer Dana → `/about`
- Twitch iframes → `title="Twitch live stream"`
- 13 redirects (sampled 4) → 301 with correct `Location`
- 3 existing photo landings → 200 (no regression)
- Dark mode toggle present, RSS feed 200, sitemap = 286 URLs

## Test plan

- [ ] Auto-tag fires on master push (next: v1.3.0 due to `#minor` bump)
- [ ] release.yml deploys the tag to whalecore.com
- [ ] Spot-check on whalecore: `/2020/04/16/the-most-boring-stream-on-twitch/cycling-animation` → 200, footer Dana → `/about`, contact page YouTube link → relative `/youtube`