### PR TITLE
Release v1.3.1: develop → master #patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,13 @@ jobs:
           middleman-
     - name: Build the static site
       run: bundle exec middleman build --bail
-    - name: Deploy to Cloudflare Pages (staging)
+    - name: Deploy to Cloudflare Pages (production)
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      # Tag pushes have detached HEAD; without --branch, wrangler defaults
-      # to the "head" alias and the deploy never reaches the production
-      # alias serving whalecore.com. Pin to master so releases promote.
-      run: npx wrangler pages deploy build/ --project-name dana-lol-staging --branch master
+      # Tag pushes have detached HEAD; pin to master so the deploy
+      # lands on the production alias serving www.dana.lol.
+      run: npx wrangler pages deploy build/ --project-name dana-lol-production --branch master
 
     - name: Post Discord notification
       env:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,30 @@
+name: Staging
+on:
+  push:
+    branches: [develop]
+
+# Build settings mirror testing.yml: ENV=test skips image optimization,
+# which is fine for staging where merges land more often than tag releases.
+env:
+  ENV: test
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version-file: .tool-versions
+        bundler-cache: true
+    - name: Build the static site
+      run: bundle exec middleman build --bail
+    - name: Deploy to Cloudflare Pages (staging)
+      env:
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      # The staging CF Pages project's production_branch is "master", and
+      # its master alias is what serves www.whalecore.com. Pinning to
+      # --branch master here means develop merges land on whalecore.com.
+      run: npx wrangler pages deploy build/ --project-name dana-lol-staging --branch master

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,9 +1,10 @@
 # Taskfile for the dana.lol Middleman site.
 #
-# Cloudflare Pages is the new staging deploy target (deploy:stage).
-# Production currently still serves from S3 — see :s3-suffixed tasks.
-# A follow-up will add a Cloudflare prod target (deploy:prod) once the
-# dana-lol Pages project is provisioned in terraform/prod-1/.
+# Cloudflare Pages is the deploy target for both staging (deploy:stage,
+# project: dana-lol-staging, custom domain: www.whalecore.com) and
+# production (deploy:prod, project: dana-lol-production, custom domain:
+# www.dana.lol). The :s3-suffixed tasks are retained as a fallback in
+# case CF Pages needs to be rolled back.
 
 version: '3'
 
@@ -31,10 +32,21 @@ tasks:
       - task: build:fast
       - task: deploy:stage
 
+  deploy:prod:
+    desc: Deploy build/ to Cloudflare Pages production (dana-lol-production)
+    cmds:
+      - npx wrangler pages deploy build/ --project-name dana-lol-production --branch master
+
+  release:prod:
+    desc: Build (with image optimization) and deploy to Cloudflare Pages production
+    cmds:
+      - task: build
+      - task: deploy:prod
+
   # --- Legacy S3 paths ------------------------------------------------------
-  # Staging S3 retained as a fallback in case the Cloudflare Pages staging
-  # path needs to be rolled back. Prod S3 is the current production target
-  # for www.dana.lol (no Cloudflare prod project exists yet).
+  # Retained as a fallback in case the Cloudflare Pages path needs to
+  # be rolled back. Both staging and prod CF Pages projects are now the
+  # default deploy targets (deploy:stage, deploy:prod).
 
   deploy:stage:s3:
     desc: (fallback) Push build/ to staging S3 (set STAGE_S3_BUCKET and STAGE_CLOUDFRONT_DISTRIBUTION_ID)
@@ -45,7 +57,7 @@ tasks:
       - bundle exec s3_website push --site build
 
   deploy:prod:s3:
-    desc: Push build/ to prod S3 — current www.dana.lol target (set PROD_S3_BUCKET and PROD_CLOUDFRONT_DISTRIBUTION_ID)
+    desc: (fallback) Push build/ to prod S3 (set PROD_S3_BUCKET and PROD_CLOUDFRONT_DISTRIBUTION_ID)
     env:
       STATIC_SITE_BUCKET: $PROD_S3_BUCKET
       STATIC_SITE_CLOUDFRONT: $PROD_CLOUDFRONT_DISTRIBUTION_ID
@@ -59,7 +71,7 @@ tasks:
       - task: deploy:stage:s3
 
   release:prod:s3:
-    desc: Build (with image optimization) and deploy to prod S3 (current prod)
+    desc: (fallback) Build (with image optimization) and deploy to prod S3
     cmds:
       - task: build
       - task: deploy:prod:s3


### PR DESCRIPTION
## Summary

First release through the new tag-trigger flow with prod targeting CF Pages (#195). The patch bumps v1.3.0 → v1.3.1; no site content changes since v1.3.0 — this release is a smoke test of the full pipeline.

## Pipeline under test

\`\`\`
merge this PR (merge commit, NOT squash)
  → master gains commit
  → auto-tag.yml fires → tag v1.3.1
  → release.yml fires (push: tags v*)
  → wrangler pages deploy to dana-lol-production --branch master
  → www.dana.lol updates
  → Discord notification
\`\`\`

## Commits in this release

- \`2d003bb\` — ci: split flow into staging.yml (develop→whalecore) + release.yml prod (master→dana.lol) (#195)

## Merge strategy

**Use "Create a merge commit"** — develop→master release PRs use merge commits per [[../decisions/merge-strategy-by-target-branch]] / `feedback_merge_strategy_by_branch` to avoid phantom divergence on the next release.

## Test plan

- [ ] auto-tag.yml creates v1.3.1
- [ ] release.yml deploys to dana-lol-production successfully
- [ ] Discord notification lands
- [ ] www.dana.lol returns 200 from Cloudflare with current content
- [ ] staging.dana.lol still serving (was updated by staging.yml when #195 merged to develop)