### PR TITLE
deps: bundled Dependabot patch bumps (May 2026 batch)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
     progress (3.6.0)
     public_suffix (7.0.5)
     racc (1.8.1)
-    rack (3.1.20)
+    rack (3.1.21)
     rack-livereload (0.6.1)
       rack (>= 3.0, < 3.2)
     rackup (2.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     awesome_print (1.9.2)
     base64 (0.3.0)


### PR DESCRIPTION
Bundled Dependabot bump batch so CI runs once instead of twice.

## What's in here

- #175 `addressable` 2.8.9 → 2.9.0
- #174 `rack` 3.1.20 → 3.1.21

## What's not in here

- #180 `nokogiri` 1.19.2 → 1.19.3 — UNSTABLE (one failing check). Pulled out for separate investigation.
- The CONFLICTING action bumps (#169-#173) — recent ones can rebase via `@dependabot rebase`; some are major (`actions/checkout` 2→6, `actions/github-script` 4→8) and warrant individual review.
- The ancient bundler bumps (#21, #46, #104, #107, #137, #152, #154) — superseded by current Gemfile.lock; recommend closing rather than rebasing.

## Merge plan

- Squash-merge into `develop` once green.
- After this lands, close #174 and #175 with a "rolled into #<this>" note.