### PR TITLE
ci: bump GHA actions to latest (checkout v6, sticky-pull-request-comment v3)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -8,7 +8,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,7 +6,7 @@ jobs:
     name: misspell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: misspell
         uses: reviewdog/action-misspell@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
       # fetch-depth: 0 is required by super-linter v6+: it diffs against
       # the default branch (master) to figure out which files changed,
       # which means master has to be present in the local checkout.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: run-linters

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@ jobs:
         alias=$(grep "Deployment alias URL:" wrangler.out | grep -oE 'https://[^ ]+' | tail -1)
         echo "alias=$alias" >> "$GITHUB_OUTPUT"
     - name: Sticky preview URL comment
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       with:
         header: cf-preview
         message: |

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.CI_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Bumps every pinned GitHub Action in the website to its current latest, by directly editing the workflows. Actions on floating major tags (`@v1`, `@v2`, etc.) auto-cover and are unchanged.

## Bumps in this PR

- `actions/checkout` v4 → v6 (across 7 workflows)
- `marocchino/sticky-pull-request-comment` v2 → v3 (1 workflow)

Both v6/v3 are Node 24 majors with no API surface changes (release notes verified).

## Floating tags already at latest

`actions/cache@v5`, `anothrNick/github-tag-action@1`, `Ilshidur/action-discord@0.4.0`, `reviewdog/action-misspell@v1`, `ruby/setup-ruby@v1`, `super-linter/super-linter@v8.6.0`, `ankitvgupta/pr-updater@v1.4.0` — all on latest major or pinned-at-current.

## Replaces

- #171 `actions/checkout` 2 → 6 (was on a stale base; close after this lands)

The other website Dependabot GHA PRs (#169, #170, #172, #173) were closed earlier as already-superseded by current workflows.

## Merge plan

Squash-merge into `develop`. After this lands, close #171 with a "rolled into #198" note.