### PR TITLE
ci: skip CF preview deploy on Dependabot PRs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,8 +22,13 @@ jobs:
         bundler-cache: true
     - name: Build the static site
       run: bundle exec middleman build --bail
+    # Skip CF Pages deploy for Dependabot PRs: GitHub deliberately
+    # withholds repo secrets from Dependabot-triggered runs, so
+    # CLOUDFLARE_API_TOKEN comes through blank and wrangler fails.
+    # Dep bumps don't need a preview deploy anyway.
     - name: Deploy to Cloudflare Pages (staging)
       id: deploy
+      if: github.actor != 'dependabot[bot]'
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -34,6 +39,7 @@ jobs:
         alias=$(grep "Deployment alias URL:" wrangler.out | grep -oE 'https://[^ ]+' | tail -1)
         echo "alias=$alias" >> "$GITHUB_OUTPUT"
     - name: Sticky preview URL comment
+      if: github.actor != 'dependabot[bot]'
       uses: marocchino/sticky-pull-request-comment@v3
       with:
         header: cf-preview


### PR DESCRIPTION
GitHub deliberately withholds repo secrets from Dependabot-triggered workflow runs, which means `CLOUDFLARE_API_TOKEN` comes through blank and wrangler fails with "Not logged in". This currently breaks every Dependabot PR's `Testing` workflow — most recently #180 (nokogiri 1.19.2 → 1.19.3).

Adds `if: github.actor != 'dependabot[bot]'` to the deploy + sticky-comment steps. Dependabot PRs still build the site (the build step proves the bump didn't break things), but skip the CF Pages preview.

## Why this over Dependabot Secrets

Adding `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` as Dependabot Secrets would also work, but:
- Dep-bump runs are exactly the runs we *least* want to hand a CF token to (third-party gem updates can include build-time hooks).
- Preview deploys aren't useful for vendor bumps.
- This keeps configuration in code rather than GH UI state.

## Test plan

- After merge: trigger #180's CI by commenting `@dependabot rebase`. The build job should run, skip the deploy step, and pass.
- A regular human PR should still get its preview URL sticky comment as before.