### PR TITLE
deps: bump bundler 2.6.9 → 4.0.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,4 +229,4 @@ DEPENDENCIES
   redcarpet
 
 BUNDLED WITH
-   2.6.9
+  4.0.11


### PR DESCRIPTION
## Summary
- Bumps bundler from 2.6.9 to 4.0.11 (the current stable — bundler skipped 3.x entirely).
- Single-line change: `BUNDLED WITH` in `Gemfile.lock`.
- Middleman's `bundler (> 2.0)` constraint is satisfied by 4.x.
- CI auto-picks up the new bundler via `ruby/setup-ruby@v1` + `bundler-cache: true` reading `BUNDLED WITH` — no workflow changes needed.

## Why 4.x, not 2.7.x
4.0 was released as a true major (no stable 3.x line exists to land on). Reviewed the 4.0 breaking-changes list; none affect this Gemfile (no multi-source, no remembered CLI flags, no `bundle install --binstubs`, no `bundle show --outdated`, etc.).

## Verification
- Baselined `middleman build` output under bundler 2.6.9 (`ENV=test`, full 554-file output).
- Bumped to 4.0.11, rebuilt, diffed.
- 14 of 15 differing files are pre-existing `mn-NN` / `sn-NN` CSS ID shifts from auto-incrementing counters in `helpers/dana_lol_helpers.rb` (already non-deterministic across consecutive same-gem builds — not caused by this bump).
- 1 structural diff: `article-template/index.html`, which intentionally uses `<%= lorem.paragraph %>` for random Latin.
- Output is structurally identical when mn/sn IDs are normalized.

## Test plan
- [ ] CI passes (this is the real bundler 4 smoke test)
- [ ] `<branch>.dana-lol-staging.pages.dev` preview renders cleanly