### PR TITLE
deps: bump parallel 1.27.0 → 2.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       padrino-support (= 0.16.1)
       tilt (>= 2.1, < 3)
     padrino-support (0.16.1)
-    parallel (1.27.0)
+    parallel (2.1.0)
     parslet (2.0.0)
     prism (1.9.0)
     progress (3.6.0)


### PR DESCRIPTION
## Summary
- Bumps `parallel` (transitive — used by middleman-core) from 1.27.0 to 2.1.0.
- Single-line `Gemfile.lock` change.
- 2.0's only breaking change is "Require Ruby >= 3.3" — we're on 3.4.9.
- 2.1.0 adds optional serializer support (additive).
- Middleman-core has no version constraint on parallel.

## Verification
- Baselined `middleman build` output under parallel 1.27.0 (`ENV=test`).
- Bumped to 2.1.0, rebuilt, diffed.
- 19 files differed; 18 are pre-existing `mn-NN` / `sn-NN` CSS ID shifts from the auto-incrementing counters in `helpers/dana_lol_helpers.rb` (already non-deterministic across consecutive same-gem builds).
- 1 structural diff: `article-template/index.html`, which uses `<%= lorem.paragraph %>` for random Latin.
- Output is structurally identical when mn/sn IDs are normalized.

## Test plan
- [ ] CI passes
- [ ] `<branch>.dana-lol-staging.pages.dev` preview renders cleanly