### PR TITLE
fix: restore image optimization on build

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -115,6 +115,52 @@ configure :build do
   activate :minify_html
 
   # Minify images on build
+  #
+  # Two fixes are needed for middleman-images 0.2.0 against this blog setup;
+  # without them image optimization is silently a no-op (templates render with
+  # the original src, no -opt resource is generated):
+  #
+  # 1. Priority 120 (default 50) so the manipulator runs after directory_indexes
+  #    (100) and Collections (110, which realizes app.data). Otherwise the
+  #    inspector's `resource.render({}, {})` pass sees `current_article.url`
+  #    still in `.html` form, and the lazy `data.ogp.og` accessor resolves to
+  #    nil — both of which make `<%= figure "#{current_article.url}foo.jpg" %>`
+  #    look up a malformed path that doesn't exist in the sitemap.
+  # 2. Lookup by destination_path, not source path. middleman-images' built-in
+  #    `image_path` calls `find_resource_by_path`, but blog images have
+  #    `path = 2017-11-27-foo/img.jpg` (source-file form) while their
+  #    `destination_path = 2017/11/27/foo/img.jpg` (URL form). Templates
+  #    reference the URL form, so the path-based lookup misses every blog image.
+  Middleman::Images::Extension.resource_list_manipulator_priority = 120
+  Middleman::Images::Extension.class_eval do
+    def image_path(path, process_options)
+      source = app.sitemap.find_resource_by_destination_path(send(:absolute_path, path))
+      return path if source.nil?
+
+      process_options[:image_optim] = options[:image_optim]
+      process_options[:optimize] = options[:optimize] unless process_options.key?(:optimize)
+
+      if process_options[:resize] || process_options[:optimize]
+        processed_path = Pathname.new(send(:add_processed_resource, source, process_options))
+        path = processed_path.relative_path_from(Pathname.new(app.config[:images_dir])).to_s
+      else
+        @manipulator.preserve_original source
+      end
+
+      path
+    end
+
+    # Build the -opt resource path off destination_path (URL form) instead of
+    # normalized_path (source-file form). Otherwise blog images get optimized
+    # to /2017-11-27-foo/img-opt.jpg instead of /2017/11/27/foo/img-opt.jpg
+    # and the rendered HTML 404s in prod.
+    def build_processed_path(source, process_options)
+      destination = source.destination_path.sub(/#{source.ext}$/, "")
+      destination += "-" + CGI.escape(process_options[:resize].to_s) if process_options[:resize]
+      destination += "-opt" if process_options[:optimize]
+      destination + source.ext
+    end
+  end
   activate :images do |images|
     images.optimize = ENV['ENV'] != 'test'
     # see https://github.com/toy/image_optim for all available options


### PR DESCRIPTION
## Summary
Image optimization has been silently disabled since [#189](https://github.com/adanalife/website/pull/189) (2026-05-06). Prod is currently shipping unoptimized originals — verified by `curl`ing https://www.dana.lol/2018/03/13/trip-report-los-angeles/venice-beach-pier.JPG which returns the byte-identical 3.0 MB source.

Two issues in middleman-images 0.2.0 (latest available — gem was last released 2019), both monkeypatched in `config.rb`:

### 1. Priority

middleman-images registers at default priority 50. Its inspector calls `resource.render({}, {})` to discover `image_tag` refs in templates. At priority 50 this runs before:
- `directory_indexes` (100) — so `current_article.url` is still `.html`-suffixed, producing malformed paths like `/2017/11/27/foo.htmlpano.jpg`
- `Collections` (110, realizes `app.data`) — so the lazy `data.ogp.og` accessor in the ogp config resolves to nil, raising `NoMethodError` during render. middleman-images' `rescue` swallows the error and skips the resource.

Fix: bump priority to 120.

### 2. Lookup

After fixing priority, paths look right but resource lookup still fails for blog images. `find_resource_by_path` matches on `path`, but blog images have:
```
path             = 2017-11-27-foo/img.jpg  (source-file form)
destination_path = 2017/11/27/foo/img.jpg  (URL form)
```

Templates reference the URL form. Switching to `find_resource_by_destination_path` makes the lookup succeed for both blog and non-blog images. `build_processed_path` also needed a parallel override so optimized files land at the correct destination path.

## Why this regressed

[#189](https://github.com/adanalife/website/pull/189) replaced the `ready do { proxy ... }` photo-landing-pages loop with a sitemap manipulator. The old loop's per-call `proxy()` forced the manipulator pipeline to re-run on later passes where `directory_indexes` had already applied — masking the priority bug. The new manipulator runs once at registration order, surfacing both issues.

## Verification

Clean local build (`rm -rf build cache && middleman build --bail`):

- **177 `-opt` files generated** (was 1 — only `/about/dana.jpg` worked, since it lives outside the blog and has `path == destination_path`).
- All at correct URL-style destination paths (`/2017/11/27/...`, not `/2017-11-27-.../`).
- Rendered HTML correctly references the new `-opt` URLs.
- Sample size reductions: 6–11% across 4 spot-checked images (e.g., venice-beach-pier 3.0 MB → 2.8 MB).
- Build time on cold cache: ~8 min (matches the "~10 min with ~190 images" mentioned in the existing config.rb comment).

## CI impact

CI workflows (`testing.yml`, `staging.yml`, `release.yml`) run `bundle exec middleman build --bail` without `ENV=test`, so they'll now do real image optim instead of no-opping. Expect those jobs to go from a few minutes to ~10 min on a fresh runner. Manageable; the cache helps but Actions runners start fresh each run.

## Test plan
- [ ] CI passes
- [ ] `<branch>.dana-lol-staging.pages.dev` preview renders cleanly with optimized image refs
- [ ] Spot-check that `<img src=...-opt.jpg>` URLs in the preview return 200 with smaller bytes than the originals