### PR TITLE
ci(staging): mirror prod build (drop ENV=test)

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,11 +3,6 @@ on:
   push:
     branches: [develop]
 
-# Build settings mirror testing.yml: ENV=test skips image optimization,
-# which is fine for staging where merges land more often than tag releases.
-env:
-  ENV: test
-
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Drop the workflow-level `env: ENV: test` from `staging.yml` so develop merges to whalecore.com mirror what release.yml produces for dana.lol.

## Why

`ENV=test` flips `images.optimize = false` in the `configure :build` block of `config.rb`, so staging was never exercising the image-optimization pipeline. That gap is what let the broken-since-[#189](https://github.com/adanalife/website/pull/189) image-optim regression hide on staging for ~6 weeks before [#205](https://github.com/adanalife/website/pull/205) fixed it.

The original `ENV=test` was a deliberate speed optimization, but the calculus changed:
- **Pre-merge fast feedback** is `testing.yml`'s job (PR builds keep `ENV=test`).
- **Staging is the dress rehearsal for prod** and should match the prod build path.
- **Catching pipeline regressions** before they hit prod is worth ~10 min per develop merge.

## Cost
Per-merge build goes from a few minutes to ~10 min on a fresh runner. If that becomes painful, a follow-up can add an `actions/cache` step keyed on `cache/` to claw most of that back — middleman-images caches optimized output keyed by source content, so the cache stays valid across runs unless source images change.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, the develop-triggered staging deploy completes (will be slower) and `https://www.whalecore.com/2018/03/13/trip-report-los-angeles/venice-beach-pier-opt.JPG` returns 200 (currently 404)