### PR TITLE
ci: rename CF Pages project dana-lol-staging → dana-lol-stage-1

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -22,4 +22,4 @@ jobs:
       # The staging CF Pages project's production_branch is "master", and
       # its master alias is what serves www.whalecore.com. Pinning to
       # --branch master here means develop merges land on whalecore.com.
-      run: npx wrangler pages deploy build/ --project-name dana-lol-staging --branch master
+      run: npx wrangler pages deploy build/ --project-name dana-lol-stage-1 --branch master

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,7 @@ jobs:
       shell: bash
       run: |
         set -o pipefail
-        npx wrangler pages deploy build/ --project-name dana-lol-staging --branch ${{ github.head_ref }} | tee wrangler.out
+        npx wrangler pages deploy build/ --project-name dana-lol-stage-1 --branch ${{ github.head_ref }} | tee wrangler.out
         alias=$(grep "Deployment alias URL:" wrangler.out | grep -oE 'https://[^ ]+' | tail -1)
         echo "alias=$alias" >> "$GITHUB_OUTPUT"
     - name: Sticky preview URL comment

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,7 @@
 # Taskfile for the dana.lol Middleman site.
 #
 # Cloudflare Pages is the deploy target for both staging (deploy:stage,
-# project: dana-lol-staging, custom domain: www.whalecore.com) and
+# project: dana-lol-stage-1, custom domain: www.whalecore.com) and
 # production (deploy:prod, project: dana-lol-production, custom domain:
 # www.dana.lol). The :s3-suffixed tasks are retained as a fallback in
 # case CF Pages needs to be rolled back.
@@ -22,9 +22,9 @@ tasks:
       - bundle exec middleman build --bail
 
   deploy:stage:
-    desc: Deploy build/ to Cloudflare Pages staging (dana-lol-staging)
+    desc: Deploy build/ to Cloudflare Pages staging (dana-lol-stage-1)
     cmds:
-      - npx wrangler pages deploy build/ --project-name dana-lol-staging
+      - npx wrangler pages deploy build/ --project-name dana-lol-stage-1
 
   release:stage:
     desc: Build (fast) and deploy to Cloudflare Pages staging


### PR DESCRIPTION
## Summary

Coordinated with [adanalife/infra#402](https://github.com/adanalife/infra/pull/402), which renames the staging Cloudflare Pages project from `dana-lol-staging` to `dana-lol-stage-1`.

Three call-sites updated:
- `Taskfile.yml` — `deploy:stage` task + header comment
- `.github/workflows/staging.yml` — develop-merge wrangler deploy
- `.github/workflows/testing.yml` — PR-preview wrangler deploy

## Sequencing

1. Merge this first.
2. Apply infra#402 — destroys `dana-lol-staging`, creates `dana-lol-stage-1`.
3. Trigger a deploy (push to develop, or `task release:stage` manually) to populate the new project.
4. Verify `https://dana-lol-stage-1.pages.dev`, `https://staging.dana.lol`, and `https://www.whalecore.com`.

Between steps 1 and 2, CI deploys point at a project that's about to be destroyed — the next staging deploy will be wasted but harmless. PR-preview deploys for any open website PR will need a re-run after step 3.

## Test plan

- [ ] PR-preview deploy succeeds on this branch (testing the *current* `dana-lol-staging` while it still exists).
- [ ] After infra#402 applies + first new deploy lands, verify staging URLs serve content from the new project.
- [ ] Open a follow-up PR to confirm `testing.yml`'s sticky preview comment lands a `dana-lol-stage-1` alias URL.