### PR TITLE
contact + ama: graceful-error UX on the forms

### DIFF
--- a/source/ama.html.md.erb
+++ b/source/ama.html.md.erb
@@ -8,8 +8,10 @@ ogp:
 Go ahead and ask me a question about anything you like.  
 I might answer it in the [FAQ](/faq)!
 
+<%# Backend: adanalife/contact-form running on the stage-1 k3d cluster.
+    Update this URL when prod-1 stands up its own deployment. %>
 <p>
-<form class="amaform" autocomplete="off" action='https://danalol-contact.herokuapp.com/' method='post'>
+<form id='ama-form' class="amaform" autocomplete="off" action='https://contact.stage.whereisdana.today/' method='post'>
   <span><label for="question">What would you like to know?</label></span>
   <br>
   <input class="question" id="question" name="message" type="text"/>
@@ -17,5 +19,43 @@ I might answer it in the [FAQ](/faq)!
     <input type="submit" value="Submit" class="btn">
   </p>
 </form>
+<p id='ama-form-status' role='status' aria-live='polite' hidden></p>
+<noscript>
+  <p><em>Form not working? You can email me directly at
+  <a href='mailto:danadotlol@gmail.com'>danadotlol@gmail.com</a>.</em></p>
+</noscript>
 </p>
+
+<script>
+  (function () {
+    var form = document.getElementById('ama-form');
+    if (!form) return;
+    var status = document.getElementById('ama-form-status');
+
+    form.addEventListener('submit', function (ev) {
+      ev.preventDefault();
+      status.hidden = false;
+      status.textContent = 'Sending…';
+
+      fetch(form.action, {
+        method: 'POST',
+        body: new URLSearchParams(new FormData(form)),
+        mode: 'cors',
+        redirect: 'manual',
+        credentials: 'omit'
+      }).then(function (res) {
+        if (res.type === 'opaqueredirect' || res.ok) {
+          form.style.display = 'none';
+          status.textContent = 'Question received — thanks!';
+        } else {
+          throw new Error('HTTP ' + res.status);
+        }
+      }).catch(function () {
+        status.innerHTML = 'Sorry, the form is having trouble right now. ' +
+          'You can email me directly at ' +
+          '<a href="mailto:danadotlol@gmail.com">danadotlol@gmail.com</a>.';
+      });
+    });
+  })();
+</script>
 

--- a/source/contact.html.md.erb
+++ b/source/contact.html.md.erb
@@ -20,8 +20,10 @@ You can find me on the following sites and contact me through there.
 
 ## Contact Dana
 
+<%# Backend: adanalife/contact-form running on the stage-1 k3d cluster.
+    Update this URL when prod-1 stands up its own deployment. %>
 <p>
-  <form action='https://danalol-contact.herokuapp.com/' method='post'>
+  <form id='contact-form' action='https://contact.stage.whereisdana.today/' method='post'>
     <p>
     <label>Your name and message:</label><br>
     <textarea name='message' class='contact'></textarea>
@@ -34,5 +36,46 @@ You can find me on the following sites and contact me through there.
     <input type='submit' value='Send!' class='btn'>
     </p>
   </form>
+  <p id='contact-form-status' role='status' aria-live='polite' hidden></p>
+  <noscript>
+    <p><em>Form not working? You can email me directly at
+    <a href='mailto:danadotlol@gmail.com'>danadotlol@gmail.com</a>.</em></p>
+  </noscript>
 </p>
+
+<script>
+  (function () {
+    var form = document.getElementById('contact-form');
+    if (!form) return;
+    var status = document.getElementById('contact-form-status');
+
+    form.addEventListener('submit', function (ev) {
+      ev.preventDefault();
+      status.hidden = false;
+      status.textContent = 'Sending…';
+
+      fetch(form.action, {
+        method: 'POST',
+        body: new URLSearchParams(new FormData(form)),
+        mode: 'cors',
+        // Don't follow the backend's 302 to /success — that crosses
+        // origins again and trips CORS on the redirected GET. The
+        // opaqueredirect response is enough to know it succeeded.
+        redirect: 'manual',
+        credentials: 'omit'
+      }).then(function (res) {
+        if (res.type === 'opaqueredirect' || res.ok) {
+          form.style.display = 'none';
+          status.textContent = 'Thanks for reaching out — it really means a lot.';
+        } else {
+          throw new Error('HTTP ' + res.status);
+        }
+      }).catch(function () {
+        status.innerHTML = 'Sorry, the form is having trouble right now. ' +
+          'You can email me directly at ' +
+          '<a href="mailto:danadotlol@gmail.com">danadotlol@gmail.com</a>.';
+      });
+    });
+  })();
+</script>
 


### PR DESCRIPTION
## Summary

Phase 4 of the contact-form rebuild. Both forms (`/contact` and `/ama`) post to the dead Heroku backend today, which has been returning 503 since Heroku's free tier retired in 2022 — visitors hitting "submit" get a raw 503 page. Pointing the forms at the rebuilt backend and adding a JS hijack so the failure mode is graceful when the backend is down.

Pairs with [adanalife/contact-form#1](https://github.com/adanalife/contact-form/pull/1) (Phase 1, modernized backend) and [adanalife/infra#422](https://github.com/adanalife/infra/pull/422) (Phases 2+3, AWS + k8s deploy).

### What changes

Per form (`source/contact.html.md.erb` + `source/ama.html.md.erb`):

- **`action=` repointed** to `https://contact.stage.whereisdana.today/`. Comment notes to update when prod-1 lands its own deployment.
- **Stable `id`** (`contact-form`, `ama-form`) for JS targeting.
- **Sibling status `<p>`** with `role="status"` + `aria-live="polite"`, hidden initially. Updated by JS to show "Sending…", thank-you, or error.
- **`<noscript>` fallback** with a `mailto:danadotlol@gmail.com` link — visible only when JS is off.
- **Inline `<script>`** intercepts the submit:
  - `fetch()` with `redirect: 'manual'` — the backend returns 302 to `https://www.dana.lol/success`, which is cross-origin from `staging.dana.lol`/`whalecore.com` and would re-trigger CORS on the redirected GET. `opaqueredirect` is enough signal to know the POST succeeded.
  - On success, hide the form and replace the status with a thank-you message.
  - On network error or non-success status, render an inline error with a `mailto:` link so visitors still have a path through.

### Three failure modes, all covered

| Scenario | Behavior |
|---|---|
| JS disabled | `<noscript>` shows the mailto link; native form POST + redirect to `/success` works as before |
| JS on, backend up | `fetch()` succeeds (opaqueredirect), form hidden, "Thanks for reaching out" in the status |
| JS on, backend down | `fetch()` errors caught, inline message: "Sorry, the form is having trouble — email me directly at danadotlol@gmail.com" |

### Things to flag

- **Backend allowlist**: the contact-form's `ALLOWLIST` ConfigMap entry covers `https://www.dana.lol`, `https://dana.lol`, `https://staging.dana.lol`, `https://www.whalecore.com`. CF Pages branch-preview URLs (`*.dana-lol-staging.pages.dev`) are NOT in the allowlist — the form will work on the main staging/prod URLs but not on per-branch previews unless their specific origin gets added.
- **The form won't actually work end-to-end** until [adanalife/contact-form#1](https://github.com/adanalife/contact-form/pull/1) merges + a `v0.1.0` tag is cut (so `adanalife/contact-form:latest` exists on Docker Hub) AND [adanalife/infra#422](https://github.com/adanalife/infra/pull/422) is applied (so the SES + k8s stack is up). Until then the "JS on, backend down" path will trigger and visitors see the mailto fallback.
- **The mailto fallback uses `danadotlol@gmail.com`** plain in the page HTML. Some baseline spam exposure is the trade-off for the link being usable when JS errors out (entity-encoding defeats some scrapers but not modern ones; JS-assembled emails can't be the no-JS fallback).

## Test plan

- [x] `ENV=test bundle exec middleman build --bail` succeeds
- [x] Both `build/contact/index.html` and `build/ama/index.html` contain the new `contact.stage.whereisdana.today` URL and the JS hijack; neither contains the old `danalol-contact.herokuapp.com` URL
- [ ] Manual: load `/contact` on the CF Pages preview, submit with the backend down — verify mailto fallback shows
- [ ] Manual: same on `/ama`
- [ ] Once the backend is live: submit with valid input, verify the success message shows and Dana's inbox gets the email
- [ ] Manual: load `/contact` with JS disabled (devtools), verify the `<noscript>` mailto shows