### PR TITLE
fix(faq): restore anchor TOC with HTML5 id=

### DIFF
--- a/source/faq.html.md.erb
+++ b/source/faq.html.md.erb
@@ -28,7 +28,7 @@ Something you want to know?
     <% next unless faq.published %>
     <li>
       <p>
-        <a name='<%= faq.short || faq.object_id.to_s %>'>
+        <a id='<%= faq.short || faq.object_id.to_s %>'>
           <strong><%= faq.q %></strong>
           <%= faq.a || lorem.paragraph %>
         </a>


### PR DESCRIPTION
## Summary
- The FAQ Table of Contents links (`#kind-of-van`, `#poop`, `#shower`, `#route`, `#solar`, `#electricity`, `#fridge`, `#lonely`) all failed to scroll: each entry's anchor target was `<a name='...'>`, which was removed from the HTML5 spec, and no `id=` attribute existed on the target.
- One-line template fix in `source/faq.html.md.erb`: swap `name=` for `id=` on the existing `<a>`. Rendered structure stays identical; all 8 anchors now resolve.

## Test plan
- [x] `ENV=test bundle exec middleman build --bail` succeeds.
- [x] Built `build/faq/index.html` shows `id=kind-of-van`, `id=poop`, ... `id=lonely` on the answer entries (matching the TOC `href='#...'` refs).
- [ ] After CF Pages preview deploys, click each of the 8 TOC links and confirm the page jumps to the matching answer.