### PR TITLE
ci(staging): cache middleman-images output across runs

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,26 +13,6 @@ jobs:
       with:
         ruby-version-file: .tool-versions
         bundler-cache: true
-    # Sanity-check: every image extension present under source/ must be
-    # covered by the cache-key glob below. If a new extension creeps in
-    # (e.g., someone drops a `.JPEG` or a `.HEIC`), this step catches it
-    # before the cache silently degrades to "always miss."
-    - name: Verify cache-key glob covers all image extensions
-      run: |
-        covered="jpg JPG jpeg png gif webp"
-        present=$(find source -type f -regextype posix-extended \
-          -regex '.*\.(jpg|JPG|jpeg|JPEG|png|PNG|gif|GIF|webp|WEBP|heic|HEIC)$' \
-          | sed -e 's/.*\.//' | sort -u)
-        missing=""
-        for ext in $present; do
-          echo "$covered" | grep -qw "$ext" || missing="$missing $ext"
-        done
-        if [ -n "$missing" ]; then
-          echo "::error::Image extensions present under source/ but NOT in the cache-key glob:$missing"
-          echo "::error::Update both this verification step and the 'Cache middleman-images output' step below."
-          exit 1
-        fi
-        echo "Image extensions covered: $present"
     # middleman-images caches optimized output under cache/ at the repo root,
     # keyed by source content. Caching that across runs claws back ~10 min
     # of image optimization on each develop merge. Source images are

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,6 +13,19 @@ jobs:
       with:
         ruby-version-file: .tool-versions
         bundler-cache: true
+    # middleman-images caches optimized output under cache/ at the repo root,
+    # keyed by source content. Caching that across runs claws back ~10 min
+    # of image optimization on each develop merge. Source images are
+    # scattered across post directories (not a single tree), so we hash the
+    # union of image extensions found under source/ — both lower- and
+    # upper-case .JPG since hashFiles globs are case-sensitive on Linux.
+    - name: Cache middleman-images output
+      uses: actions/cache@v5
+      with:
+        path: cache
+        key: middleman-images-${{ hashFiles('source/**/*.jpg', 'source/**/*.JPG', 'source/**/*.jpeg', 'source/**/*.png', 'source/**/*.gif', 'source/**/*.webp') }}
+        restore-keys: |
+          middleman-images-
     - name: Build the static site
       run: bundle exec middleman build --bail
     - name: Deploy to Cloudflare Pages (staging)

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,6 +13,26 @@ jobs:
       with:
         ruby-version-file: .tool-versions
         bundler-cache: true
+    # Sanity-check: every image extension present under source/ must be
+    # covered by the cache-key glob below. If a new extension creeps in
+    # (e.g., someone drops a `.JPEG` or a `.HEIC`), this step catches it
+    # before the cache silently degrades to "always miss."
+    - name: Verify cache-key glob covers all image extensions
+      run: |
+        covered="jpg JPG jpeg png gif webp"
+        present=$(find source -type f -regextype posix-extended \
+          -regex '.*\.(jpg|JPG|jpeg|JPEG|png|PNG|gif|GIF|webp|WEBP|heic|HEIC)$' \
+          | sed -e 's/.*\.//' | sort -u)
+        missing=""
+        for ext in $present; do
+          echo "$covered" | grep -qw "$ext" || missing="$missing $ext"
+        done
+        if [ -n "$missing" ]; then
+          echo "::error::Image extensions present under source/ but NOT in the cache-key glob:$missing"
+          echo "::error::Update both this verification step and the 'Cache middleman-images output' step below."
+          exit 1
+        fi
+        echo "Image extensions covered: $present"
     # middleman-images caches optimized output under cache/ at the repo root,
     # keyed by source content. Caching that across runs claws back ~10 min
     # of image optimization on each develop merge. Source images are


### PR DESCRIPTION
## Summary
- Cache the middleman-images `cache/` directory across `staging.yml` runs, keyed on source-image content. First run after merge populates; subsequent merges hit the cache and skip the ~10-minute image-optim pass that landed with [#207](https://github.com/adanalife/website/pull/207).
- `restore-keys` provides a soft fallback so cache hits aren't all-or-nothing on individual image changes — adding one image still reuses optimizations for the rest.
- Pinned `actions/cache@v5` (current latest stable, `v5.0.5` at time of writing).

## Test plan
- [x] YAML edit reads back with consistent step indentation
- [ ] First staging build after merge populates the cache (visible in the action's "Post Cache" step)
- [ ] Second build with no image changes restores the cache and skips most of image-optim
- [ ] Build with one new image still optimizes that image but reuses cache for the rest (partial restore via `restore-keys`)