### PR TITLE
chore(blog): add #ad disclosure to Amazon affiliate links

### DIFF
--- a/source/2017-10-11-san-francisco-emergency-radio-setup.html.md.erb
+++ b/source/2017-10-11-san-francisco-emergency-radio-setup.html.md.erb
@@ -16,7 +16,7 @@ ogp:
 _This article explains the rationale behind why you might want to add a radio to your emergency kit. If you're already convinced, skip to [part 2](/2017/10/26/setting-up-a-handheld-radio-for-emergencies/), which outlines which beginner radio to buy._
 
 <%= marginnote(
-  link_to(tag(:img, src: "#{current_article.url}uv-5r.jpg", alt: 'a photo of a handheld radio'), 'https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20', class: 'no-underline') + "You might want to add a [Baofeng UV-5R](https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20) (#ad) (~$26) to your emergency kit"
+  link_to(tag(:img, src: "#{current_article.url}uv-5r.jpg", alt: 'a photo of a handheld radio'), 'https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20', class: 'no-underline') + "You might want to add a [Baofeng UV-5R](https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20) (~$26) to your emergency kit"
 ) %>
 One of the best reasons to get into ham radio is for emergency preparedness. Living in San Francisco, there is always a chance there could be an earthquake, a tsunami, or another disaster. When the S hits the F, what are the odds your cell phone will work? Do you think you'll have access to the Internet?
 
@@ -31,7 +31,7 @@ Ham radio, aka amateur radio, deftly sidesteps this issue by requiring only two 
 Legally, you need a license to speak on the ham radio bands. Anyone can get a license, you just need to pay $15 and pass a short exam.
 The process of getting licensed is pretty easy and is documented in lots of other places, so I'm not going to go into it.
 <%= mn "The best way to learn how to use your radio correctly is to get licensed" %>
-If you're interested, pick up the _[ARRL Ham Radio License Manual](https://smile.amazon.com/ARRL-Ham-Radio-License-Manual/dp/1625950136?tag=danalol-20)_ (#ad), or start studying flash cards on [hamstudy.org](https://hamstudy.org).
+If you're interested, pick up the _[ARRL Ham Radio License Manual](https://smile.amazon.com/ARRL-Ham-Radio-License-Manual/dp/1625950136?tag=danalol-20)_, or start studying flash cards on [hamstudy.org](https://hamstudy.org).
 
 Even if you don't get licensed:
 

--- a/source/2017-10-11-san-francisco-emergency-radio-setup.html.md.erb
+++ b/source/2017-10-11-san-francisco-emergency-radio-setup.html.md.erb
@@ -13,9 +13,7 @@ ogp:
 
 ---
 
-<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
-
-_This article explains the rationale behind why you might want to add a radio to your emergency kit. If you're already convinced, skip to [part 2](/2017/10/26/setting-up-a-handheld-radio-for-emergencies/), which outlines which beginner radio to buy._
+_This article explains the rationale behind why you might want to add a radio to your emergency kit. If you're already convinced, skip to [part 2](/2017/10/26/setting-up-a-handheld-radio-for-emergencies/), which outlines which beginner radio to buy._<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
 
 <%= marginnote(
   link_to(tag(:img, src: "#{current_article.url}uv-5r.jpg", alt: 'a photo of a handheld radio'), 'https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20', class: 'no-underline') + "You might want to add a [Baofeng UV-5R](https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20) (~$26) to your emergency kit"

--- a/source/2017-10-11-san-francisco-emergency-radio-setup.html.md.erb
+++ b/source/2017-10-11-san-francisco-emergency-radio-setup.html.md.erb
@@ -13,6 +13,8 @@ ogp:
 
 ---
 
+<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
+
 _This article explains the rationale behind why you might want to add a radio to your emergency kit. If you're already convinced, skip to [part 2](/2017/10/26/setting-up-a-handheld-radio-for-emergencies/), which outlines which beginner radio to buy._
 
 <%= marginnote(

--- a/source/2017-10-11-san-francisco-emergency-radio-setup.html.md.erb
+++ b/source/2017-10-11-san-francisco-emergency-radio-setup.html.md.erb
@@ -16,7 +16,7 @@ ogp:
 _This article explains the rationale behind why you might want to add a radio to your emergency kit. If you're already convinced, skip to [part 2](/2017/10/26/setting-up-a-handheld-radio-for-emergencies/), which outlines which beginner radio to buy._
 
 <%= marginnote(
-  link_to(tag(:img, src: "#{current_article.url}uv-5r.jpg", alt: 'a photo of a handheld radio'), 'https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20', class: 'no-underline') + "You might want to add a [Baofeng UV-5R](https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20) (~$26) to your emergency kit"
+  link_to(tag(:img, src: "#{current_article.url}uv-5r.jpg", alt: 'a photo of a handheld radio'), 'https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20', class: 'no-underline') + "You might want to add a [Baofeng UV-5R](https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20) (#ad) (~$26) to your emergency kit"
 ) %>
 One of the best reasons to get into ham radio is for emergency preparedness. Living in San Francisco, there is always a chance there could be an earthquake, a tsunami, or another disaster. When the S hits the F, what are the odds your cell phone will work? Do you think you'll have access to the Internet?
 
@@ -31,7 +31,7 @@ Ham radio, aka amateur radio, deftly sidesteps this issue by requiring only two 
 Legally, you need a license to speak on the ham radio bands. Anyone can get a license, you just need to pay $15 and pass a short exam.
 The process of getting licensed is pretty easy and is documented in lots of other places, so I'm not going to go into it.
 <%= mn "The best way to learn how to use your radio correctly is to get licensed" %>
-If you're interested, pick up the _[ARRL Ham Radio License Manual](https://smile.amazon.com/ARRL-Ham-Radio-License-Manual/dp/1625950136?tag=danalol-20)_, or start studying flash cards on [hamstudy.org](https://hamstudy.org).
+If you're interested, pick up the _[ARRL Ham Radio License Manual](https://smile.amazon.com/ARRL-Ham-Radio-License-Manual/dp/1625950136?tag=danalol-20)_ (#ad), or start studying flash cards on [hamstudy.org](https://hamstudy.org).
 
 Even if you don't get licensed:
 

--- a/source/2017-10-12-how-this-site-works-p-2.html.md.erb
+++ b/source/2017-10-12-how-this-site-works-p-2.html.md.erb
@@ -13,6 +13,8 @@ ogp:
 
 ---
 
+<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
+
 In this article I'll talk the design of the site and how I did it. For technical implementation details, check out <%= link_to('part 1', '/2017/10/01/how-this-site-works/') %>.
 
 <br>

--- a/source/2017-10-12-how-this-site-works-p-2.html.md.erb
+++ b/source/2017-10-12-how-this-site-works-p-2.html.md.erb
@@ -13,9 +13,7 @@ ogp:
 
 ---
 
-<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
-
-In this article I'll talk the design of the site and how I did it. For technical implementation details, check out <%= link_to('part 1', '/2017/10/01/how-this-site-works/') %>.
+In this article I'll talk the design of the site and how I did it. For technical implementation details, check out <%= link_to('part 1', '/2017/10/01/how-this-site-works/') %>.<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
 
 <br>
 

--- a/source/2017-10-12-how-this-site-works-p-2.html.md.erb
+++ b/source/2017-10-12-how-this-site-works-p-2.html.md.erb
@@ -27,7 +27,7 @@ Nowadays that is horrible practice, and I want to follow best practices wherever
 
 So I know that I needed an off-the-shelf template for the visual design.
 I wanted something that followed best practices so I wouldn't have to figure them out, or embarrass myself by reinventing the wheel.
-<%= marginnote(link_to(image_tag("#{current_article.url}the-visual-display-of-quantitative-information.jpg", alt: 'an image of the cover of The Visual Display of Quantitative Information by Edward Tufte'), 'https://smile.amazon.com/Visual-Display-Quantitative-Information/dp/0961392142?tag=danalol-20', class: 'no-underline')) %>
+<%= marginnote(link_to(image_tag("#{current_article.url}the-visual-display-of-quantitative-information.jpg", alt: 'an image of the cover of The Visual Display of Quantitative Information by Edward Tufte'), 'https://smile.amazon.com/Visual-Display-Quantitative-Information/dp/0961392142?tag=danalol-20', class: 'no-underline') + content_tag(:small, ' (#ad)')) %>
 
 <br>
 
@@ -35,7 +35,7 @@ I wanted something that followed best practices so I wouldn't have to figure the
 a champion in the field of information design.
 If you've never seen his work, I can't recommend him enough.
 He uses very simple design, copious whitespace, and tightly-coupled images to present a ton of information in a very digestible way.
-His most famous work, <%= link_to('his book _The Visual Display of Quantitative Information_', 'https://smile.amazon.com/Visual-Display-Quantitative-Information/dp/0961392142?tag=danalol-20') %>, is a wonderful guide to presenting complex information using graphics, charts, and tables.
+His most famous work, <%= link_to('his book _The Visual Display of Quantitative Information_', 'https://smile.amazon.com/Visual-Display-Quantitative-Information/dp/0961392142?tag=danalol-20') %> (#ad), is a wonderful guide to presenting complex information using graphics, charts, and tables.
 This book belongs on the shelf of anyone who loves data, infographics, or appealing graphic design.
 
 <%= epigraph('My books are <a href="https://github.com/adanalife/website/blob/master/source/2017-10-12-how-this-site-works-p-2.html.md.erb">self-exemplifying</a>; the objects themselves embody the ideas written about.', 'Edward Tufte, "<em>Beautiful Evidence</em>"') %>

--- a/source/2017-10-12-how-this-site-works-p-2.html.md.erb
+++ b/source/2017-10-12-how-this-site-works-p-2.html.md.erb
@@ -27,7 +27,7 @@ Nowadays that is horrible practice, and I want to follow best practices wherever
 
 So I know that I needed an off-the-shelf template for the visual design.
 I wanted something that followed best practices so I wouldn't have to figure them out, or embarrass myself by reinventing the wheel.
-<%= marginnote(link_to(image_tag("#{current_article.url}the-visual-display-of-quantitative-information.jpg", alt: 'an image of the cover of The Visual Display of Quantitative Information by Edward Tufte'), 'https://smile.amazon.com/Visual-Display-Quantitative-Information/dp/0961392142?tag=danalol-20', class: 'no-underline') + content_tag(:small, ' (#ad)')) %>
+<%= marginnote(link_to(image_tag("#{current_article.url}the-visual-display-of-quantitative-information.jpg", alt: 'an image of the cover of The Visual Display of Quantitative Information by Edward Tufte'), 'https://smile.amazon.com/Visual-Display-Quantitative-Information/dp/0961392142?tag=danalol-20', class: 'no-underline')) %>
 
 <br>
 
@@ -35,7 +35,7 @@ I wanted something that followed best practices so I wouldn't have to figure the
 a champion in the field of information design.
 If you've never seen his work, I can't recommend him enough.
 He uses very simple design, copious whitespace, and tightly-coupled images to present a ton of information in a very digestible way.
-His most famous work, <%= link_to('his book _The Visual Display of Quantitative Information_', 'https://smile.amazon.com/Visual-Display-Quantitative-Information/dp/0961392142?tag=danalol-20') %> (#ad), is a wonderful guide to presenting complex information using graphics, charts, and tables.
+His most famous work, <%= link_to('his book _The Visual Display of Quantitative Information_', 'https://smile.amazon.com/Visual-Display-Quantitative-Information/dp/0961392142?tag=danalol-20') %>, is a wonderful guide to presenting complex information using graphics, charts, and tables.
 This book belongs on the shelf of anyone who loves data, infographics, or appealing graphic design.
 
 <%= epigraph('My books are <a href="https://github.com/adanalife/website/blob/master/source/2017-10-12-how-this-site-works-p-2.html.md.erb">self-exemplifying</a>; the objects themselves embody the ideas written about.', 'Edward Tufte, "<em>Beautiful Evidence</em>"') %>

--- a/source/2017-10-26-setting-up-a-handheld-radio-for-emergencies.html.md.erb
+++ b/source/2017-10-26-setting-up-a-handheld-radio-for-emergencies.html.md.erb
@@ -20,27 +20,29 @@ In this article I will walk through purchasing and setting up your own radio.
 
 _**Important note!** Talking over a radio without an FCC license is against the law. You can, however, listen all you want, and you may talk over it in an emergency. I highly recommend you get licensed if this kind of stuff is interesting to you._
 
-I suggest buying a [Baofeng UV-5R](https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20) (~$26) for your emergency kit.
+I suggest buying a [Baofeng UV-5R](https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20) (#ad) (~$26) for your emergency kit.
 They're very useful radios for their price, and they will allow you to dip your toe into the amateur radio world without spending a fortune.
 
 <%# the direct link here is because we already included this image in another article %>
 <%= linked_figure('/2017/10/11/san-francisco-emergency-radio-setup/uv-5r.jpg', 'https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20', 'a photo of a handheld radio') %>
+<small>(#ad)</small>
 
 If you've ever used a walkie talkie, you will find operating a radio is pretty straightforward.
 The big difference is that with a ham radio, there's a ton more channels you can tune to.
 Finding someone to talk to can be overwhelming...
-it's similar to finding a good FM radio station when you're traveling out-of-state, but with the added challenge of most stations being silent almost all of the time.<%= sn 'You might want to buy a ["Nifty" UV-5R Reference Manual](https://smile.amazon.com/Baofeng-UV-5R-Tri-Folded-Reference-Accessories/dp/B018GM9OJG?tag=danalol-20), which is much easier to understand than the manual that comes with your radio.' %>
+it's similar to finding a good FM radio station when you're traveling out-of-state, but with the added challenge of most stations being silent almost all of the time.<%= sn 'You might want to buy a ["Nifty" UV-5R Reference Manual](https://smile.amazon.com/Baofeng-UV-5R-Tri-Folded-Reference-Accessories/dp/B018GM9OJG?tag=danalol-20) (#ad), which is much easier to understand than the manual that comes with your radio.' %>
 
 In any given geographic area, there are certain frequencies where people tend to hang out, or frequencies where emergency responders communicate.
 The trick is to pre-program your radio with these frequencies so you do not struggle to find someone during an emergency.
 
 <%= linked_figure("#{current_article.url}uv-5r-usb-cable.jpg", 'https://smile.amazon.com/Baofeng-Programming-Cable-BAOFENG-BF-888S/dp/B00CP0I474?tag=danalol-20', 'a photo of a Baofeng USB cable') %>
+<small>(#ad)</small>
 
 The absolute easiest way to set up your radio is to use a USB cable to program your radio via your computer.
 <%= sn "If this seems too complex, [reach out to me](/contact) and I can sell you a pre-programmed radio." %>
 I'll walk you through the basic steps:
 
-1. Purchase a <%= link_to 'BaoFeng Programming Cable', 'https://smile.amazon.com/Baofeng-Programming-Cable-BAOFENG-BF-888S/dp/B00CP0I474?tag=danalol-20' %> (~$5)
+1. Purchase a <%= link_to 'BaoFeng Programming Cable', 'https://smile.amazon.com/Baofeng-Programming-Cable-BAOFENG-BF-888S/dp/B00CP0I474?tag=danalol-20' %> (#ad) (~$5)
 2. Download and install [`chirp`](http://chirp.danplanet.com)
 3. Download the <%= link_to 'useful SF frequencies', "Baofeng_UV-5R_#{current_article.data.config_version}.csv" %> file I prepared for you
 4. Connect your radio to your computer with the USB cable and launch `chirp`

--- a/source/2017-10-26-setting-up-a-handheld-radio-for-emergencies.html.md.erb
+++ b/source/2017-10-26-setting-up-a-handheld-radio-for-emergencies.html.md.erb
@@ -15,9 +15,7 @@ ogp:
 
 ---
 
-<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
-
-In [part 1](/2017/10/11/san-francisco-emergency-radio-setup) of this series, I wrote about why a San Francisco resident might want to keep a cheap two-way radio with their emergency supplies.
+In [part 1](/2017/10/11/san-francisco-emergency-radio-setup) of this series, I wrote about why a San Francisco resident might want to keep a cheap two-way radio with their emergency supplies.<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
 In this article I will walk through purchasing and setting up your own radio.
 
 _**Important note!** Talking over a radio without an FCC license is against the law. You can, however, listen all you want, and you may talk over it in an emergency. I highly recommend you get licensed if this kind of stuff is interesting to you._

--- a/source/2017-10-26-setting-up-a-handheld-radio-for-emergencies.html.md.erb
+++ b/source/2017-10-26-setting-up-a-handheld-radio-for-emergencies.html.md.erb
@@ -15,6 +15,8 @@ ogp:
 
 ---
 
+<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
+
 In [part 1](/2017/10/11/san-francisco-emergency-radio-setup) of this series, I wrote about why a San Francisco resident might want to keep a cheap two-way radio with their emergency supplies.
 In this article I will walk through purchasing and setting up your own radio.
 

--- a/source/2017-10-26-setting-up-a-handheld-radio-for-emergencies.html.md.erb
+++ b/source/2017-10-26-setting-up-a-handheld-radio-for-emergencies.html.md.erb
@@ -20,29 +20,27 @@ In this article I will walk through purchasing and setting up your own radio.
 
 _**Important note!** Talking over a radio without an FCC license is against the law. You can, however, listen all you want, and you may talk over it in an emergency. I highly recommend you get licensed if this kind of stuff is interesting to you._
 
-I suggest buying a [Baofeng UV-5R](https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20) (#ad) (~$26) for your emergency kit.
+I suggest buying a [Baofeng UV-5R](https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20) (~$26) for your emergency kit.
 They're very useful radios for their price, and they will allow you to dip your toe into the amateur radio world without spending a fortune.
 
 <%# the direct link here is because we already included this image in another article %>
 <%= linked_figure('/2017/10/11/san-francisco-emergency-radio-setup/uv-5r.jpg', 'https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20', 'a photo of a handheld radio') %>
-<small>(#ad)</small>
 
 If you've ever used a walkie talkie, you will find operating a radio is pretty straightforward.
 The big difference is that with a ham radio, there's a ton more channels you can tune to.
 Finding someone to talk to can be overwhelming...
-it's similar to finding a good FM radio station when you're traveling out-of-state, but with the added challenge of most stations being silent almost all of the time.<%= sn 'You might want to buy a ["Nifty" UV-5R Reference Manual](https://smile.amazon.com/Baofeng-UV-5R-Tri-Folded-Reference-Accessories/dp/B018GM9OJG?tag=danalol-20) (#ad), which is much easier to understand than the manual that comes with your radio.' %>
+it's similar to finding a good FM radio station when you're traveling out-of-state, but with the added challenge of most stations being silent almost all of the time.<%= sn 'You might want to buy a ["Nifty" UV-5R Reference Manual](https://smile.amazon.com/Baofeng-UV-5R-Tri-Folded-Reference-Accessories/dp/B018GM9OJG?tag=danalol-20), which is much easier to understand than the manual that comes with your radio.' %>
 
 In any given geographic area, there are certain frequencies where people tend to hang out, or frequencies where emergency responders communicate.
 The trick is to pre-program your radio with these frequencies so you do not struggle to find someone during an emergency.
 
 <%= linked_figure("#{current_article.url}uv-5r-usb-cable.jpg", 'https://smile.amazon.com/Baofeng-Programming-Cable-BAOFENG-BF-888S/dp/B00CP0I474?tag=danalol-20', 'a photo of a Baofeng USB cable') %>
-<small>(#ad)</small>
 
 The absolute easiest way to set up your radio is to use a USB cable to program your radio via your computer.
 <%= sn "If this seems too complex, [reach out to me](/contact) and I can sell you a pre-programmed radio." %>
 I'll walk you through the basic steps:
 
-1. Purchase a <%= link_to 'BaoFeng Programming Cable', 'https://smile.amazon.com/Baofeng-Programming-Cable-BAOFENG-BF-888S/dp/B00CP0I474?tag=danalol-20' %> (#ad) (~$5)
+1. Purchase a <%= link_to 'BaoFeng Programming Cable', 'https://smile.amazon.com/Baofeng-Programming-Cable-BAOFENG-BF-888S/dp/B00CP0I474?tag=danalol-20' %> (~$5)
 2. Download and install [`chirp`](http://chirp.danplanet.com)
 3. Download the <%= link_to 'useful SF frequencies', "Baofeng_UV-5R_#{current_article.data.config_version}.csv" %> file I prepared for you
 4. Connect your radio to your computer with the USB cable and launch `chirp`

--- a/source/2018-02-21-trip-report-big-sur.html.md.erb
+++ b/source/2018-02-21-trip-report-big-sur.html.md.erb
@@ -133,7 +133,7 @@ My meals included:
  * Strawberries, raspberries, and Samoas Girl Scout Cookies
  * Berries and greek yogurt
  * Cheese, salami, hummus, and crackers
- * Chocolate [Soylent](http://amzn.to/2CAci9w) (#ad)
+ * Chocolate [Soylent](http://amzn.to/2CAci9w)
 
 In the next few months I would like to learn more van-friendly recipes, especially ones that use only a single pot.
 

--- a/source/2018-02-21-trip-report-big-sur.html.md.erb
+++ b/source/2018-02-21-trip-report-big-sur.html.md.erb
@@ -16,6 +16,8 @@ ogp:
 
 ---
 
+<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
+
 <%= partial 'van_stats', locals: {
   weeks: "just over 1",
   distance: "~400"

--- a/source/2018-02-21-trip-report-big-sur.html.md.erb
+++ b/source/2018-02-21-trip-report-big-sur.html.md.erb
@@ -133,7 +133,7 @@ My meals included:
  * Strawberries, raspberries, and Samoas Girl Scout Cookies
  * Berries and greek yogurt
  * Cheese, salami, hummus, and crackers
- * Chocolate [Soylent](http://amzn.to/2CAci9w)
+ * Chocolate [Soylent](http://amzn.to/2CAci9w) (#ad)
 
 In the next few months I would like to learn more van-friendly recipes, especially ones that use only a single pot.
 

--- a/source/2018-02-21-trip-report-big-sur.html.md.erb
+++ b/source/2018-02-21-trip-report-big-sur.html.md.erb
@@ -16,15 +16,13 @@ ogp:
 
 ---
 
-<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
-
 <%= partial 'van_stats', locals: {
   weeks: "just over 1",
   distance: "~400"
 }
 %>
 
-The first week is behind me, and I have returned to the land of reliable Internet and power.
+The first week is behind me, and I have returned to the land of reliable Internet and power.<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
 
 <%= f "#{current_article.url}limekiln-sunset.jpg", 'Sunset at Limekiln State Park, with a wave crashing on a rock' %>
 

--- a/source/2018-07-21-buy-packs-with-amazon-coins-on-a-mac.html.md.erb
+++ b/source/2018-07-21-buy-packs-with-amazon-coins-on-a-mac.html.md.erb
@@ -19,7 +19,7 @@ ogp:
 <%= epigraph "This article is intended to help people save money on a video game called Hearthstone.
 If this isn't relevant to you, you can skip this one." %>
 
-Don't have an Android, but want to save money in Hearthstone using [Amazon Coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20) (#ad)?
+Don't have an Android, but want to save money in Hearthstone using [Amazon Coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20)?
 Keep reading, or [click here](#guide) to jump to the step-by-step guide.
 
 <br>
@@ -27,11 +27,11 @@ Keep reading, or [click here](#guide) to jump to the step-by-step guide.
 ### About Amazon Coins
 
 <%= marginnote(
-  link_to(tag(:img, src: "#{current_article.url}coin.jpg", alt: 'a picture of an Amazon Coin (this is copyright Amazon)'), 'http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20', class: 'no-underline') + content_tag(:small, ' (#ad)')
+  link_to(tag(:img, src: "#{current_article.url}coin.jpg", alt: 'a picture of an Amazon Coin (this is copyright Amazon)'), 'http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20', class: 'no-underline')
 ) %>
 
 Hearthstone is a great game but it can be very expensive.
-Luckily there is a way to save money on packs using something called [Amazon Coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20) (#ad).
+Luckily there is a way to save money on packs using something called [Amazon Coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20).
 You buy these coins on Amazon for a discount, and use them in Hearthstone when you pay for packs.
 
 A coin is roughly equivalent to $0.01 USD.
@@ -78,5 +78,5 @@ At the payment screen, you will get a new prompt, asking you to once again log i
 Log in and complete the purchase.
 Congrats, you have now bought Hearthstone packs at a discount!
 
-Now [buy some coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20) (#ad) and start saving money!
+Now [buy some coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20) and start saving money!
 

--- a/source/2018-07-21-buy-packs-with-amazon-coins-on-a-mac.html.md.erb
+++ b/source/2018-07-21-buy-packs-with-amazon-coins-on-a-mac.html.md.erb
@@ -16,12 +16,10 @@ ogp:
       height: 250
 ---
 
-<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
-
 <%= epigraph "This article is intended to help people save money on a video game called Hearthstone.
 If this isn't relevant to you, you can skip this one." %>
 
-Don't have an Android, but want to save money in Hearthstone using [Amazon Coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20)?
+Don't have an Android, but want to save money in Hearthstone using [Amazon Coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20)?<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
 Keep reading, or [click here](#guide) to jump to the step-by-step guide.
 
 <br>

--- a/source/2018-07-21-buy-packs-with-amazon-coins-on-a-mac.html.md.erb
+++ b/source/2018-07-21-buy-packs-with-amazon-coins-on-a-mac.html.md.erb
@@ -19,7 +19,7 @@ ogp:
 <%= epigraph "This article is intended to help people save money on a video game called Hearthstone.
 If this isn't relevant to you, you can skip this one." %>
 
-Don't have an Android, but want to save money in Hearthstone using [Amazon Coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20)?
+Don't have an Android, but want to save money in Hearthstone using [Amazon Coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20) (#ad)?
 Keep reading, or [click here](#guide) to jump to the step-by-step guide.
 
 <br>
@@ -27,11 +27,11 @@ Keep reading, or [click here](#guide) to jump to the step-by-step guide.
 ### About Amazon Coins
 
 <%= marginnote(
-  link_to(tag(:img, src: "#{current_article.url}coin.jpg", alt: 'a picture of an Amazon Coin (this is copyright Amazon)'), 'http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20', class: 'no-underline')
+  link_to(tag(:img, src: "#{current_article.url}coin.jpg", alt: 'a picture of an Amazon Coin (this is copyright Amazon)'), 'http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20', class: 'no-underline') + content_tag(:small, ' (#ad)')
 ) %>
 
 Hearthstone is a great game but it can be very expensive.
-Luckily there is a way to save money on packs using something called [Amazon Coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20).
+Luckily there is a way to save money on packs using something called [Amazon Coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20) (#ad).
 You buy these coins on Amazon for a discount, and use them in Hearthstone when you pay for packs.
 
 A coin is roughly equivalent to $0.01 USD.
@@ -78,5 +78,5 @@ At the payment screen, you will get a new prompt, asking you to once again log i
 Log in and complete the purchase.
 Congrats, you have now bought Hearthstone packs at a discount!
 
-Now [buy some coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20) and start saving money!
+Now [buy some coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20) (#ad) and start saving money!
 

--- a/source/2018-07-21-buy-packs-with-amazon-coins-on-a-mac.html.md.erb
+++ b/source/2018-07-21-buy-packs-with-amazon-coins-on-a-mac.html.md.erb
@@ -16,6 +16,8 @@ ogp:
       height: 250
 ---
 
+<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
+
 <%= epigraph "This article is intended to help people save money on a video game called Hearthstone.
 If this isn't relevant to you, you can skip this one." %>
 

--- a/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
+++ b/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
@@ -51,7 +51,7 @@ I have literally hundreds of hours of video, so every time you visit you should 
 
 ### **What kind of dashcam do you use?**
 
-I am using a [VIOFO Compact A119](https://smile.amazon.com/gp/product/B01M28B92C?tag=danalol-20) (#ad) with a [polarizing filter](https://smile.amazon.com/Spytec-A11CPL-Circular-Polarizing-Reflections/dp/B01NAD4MZP?tag=danalol-20) (#ad).
+I am using a [VIOFO Compact A119](https://smile.amazon.com/gp/product/B01M28B92C?tag=danalol-20) with a [polarizing filter](https://smile.amazon.com/Spytec-A11CPL-Circular-Polarizing-Reflections/dp/B01NAD4MZP?tag=danalol-20).
 
 
 Thank you!

--- a/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
+++ b/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
@@ -15,9 +15,7 @@ ogp:
 
 ---
 
-<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
-
-I'm really excited to announce a new project I've been working on:
+I'm really excited to announce a new project I've been working on:<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
 
 <% iframe_wrapper do %>
   <iframe

--- a/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
+++ b/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
@@ -15,6 +15,8 @@ ogp:
 
 ---
 
+<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
+
 I'm really excited to announce a new project I've been working on:
 
 <% iframe_wrapper do %>

--- a/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
+++ b/source/2018-08-20-jump-into-my-passenger-seat.html.md.erb
@@ -51,7 +51,7 @@ I have literally hundreds of hours of video, so every time you visit you should 
 
 ### **What kind of dashcam do you use?**
 
-I am using a [VIOFO Compact A119](https://smile.amazon.com/gp/product/B01M28B92C?tag=danalol-20) with a [polarizing filter](https://smile.amazon.com/Spytec-A11CPL-Circular-Polarizing-Reflections/dp/B01NAD4MZP?tag=danalol-20).
+I am using a [VIOFO Compact A119](https://smile.amazon.com/gp/product/B01M28B92C?tag=danalol-20) (#ad) with a [polarizing filter](https://smile.amazon.com/Spytec-A11CPL-Circular-Polarizing-Reflections/dp/B01NAD4MZP?tag=danalol-20) (#ad).
 
 
 Thank you!

--- a/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
+++ b/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
@@ -14,6 +14,8 @@ ogp:
 
 ---
 
+<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
+
 A whole year of this.
 Aimlessly driving down American roads.
 This was my experience the year I [lived in a van](/2017/10/25/i-got-a-van/).

--- a/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
+++ b/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
@@ -14,9 +14,7 @@ ogp:
 
 ---
 
-<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
-
-A whole year of this.
+A whole year of this.<%= mn "Some links in this post are Amazon affiliate links — I get a small commission if you buy through them." %>
 Aimlessly driving down American roads.
 This was my experience the year I [lived in a van](/2017/10/25/i-got-a-van/).
 

--- a/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
+++ b/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
@@ -61,7 +61,7 @@ I didn't know if anyone would watch it, but I knew the idea was at the very leas
 ## 250+ Hours of Footage
 
 While premise was simple, it wasn't easy.
-The SD card in [my dashcam](https://smile.amazon.com/gp/product/B01M28B92C?tag=danalol-20) could only hold around 8 hours of footage; if I waited too long the oldest footage would be overwritten.
+The SD card in [my dashcam](https://smile.amazon.com/gp/product/B01M28B92C?tag=danalol-20) (#ad) could only hold around 8 hours of footage; if I waited too long the oldest footage would be overwritten.
 <%= marginnote("Unfortunately this did happen on occasion, most notably I lost many hours of gorgeous footage of [Badlands National Park](https://en.wikipedia.org/wiki/Badlands_National_Park)") %>
 Every couple days I had to pull out my laptop and back up the footage to an 8TB external hard drive.
 When I had reliable wifi, I backed up the footage to the cloud (using Amazon Glacier).

--- a/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
+++ b/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
@@ -61,7 +61,7 @@ I didn't know if anyone would watch it, but I knew the idea was at the very leas
 ## 250+ Hours of Footage
 
 While premise was simple, it wasn't easy.
-The SD card in [my dashcam](https://smile.amazon.com/gp/product/B01M28B92C?tag=danalol-20) (#ad) could only hold around 8 hours of footage; if I waited too long the oldest footage would be overwritten.
+The SD card in [my dashcam](https://smile.amazon.com/gp/product/B01M28B92C?tag=danalol-20) could only hold around 8 hours of footage; if I waited too long the oldest footage would be overwritten.
 <%= marginnote("Unfortunately this did happen on occasion, most notably I lost many hours of gorgeous footage of [Badlands National Park](https://en.wikipedia.org/wiki/Badlands_National_Park)") %>
 Every couple days I had to pull out my laptop and back up the footage to an 8TB external hard drive.
 When I had reliable wifi, I backed up the footage to the cloud (using Amazon Glacier).


### PR DESCRIPTION
## Summary

Adds a single top-of-post Tufte-style marginnote disclosing affiliate links on each post that contains them. Same 7 affected posts as the original per-link approach (reverted in the first commit on this branch); just a different shape.

Why the change: the per-link `(#ad)` shorthand is social-media convention and doesn't read naturally in a Tufte-style blog. A single top-of-post marginnote stating *"Some links in this post are Amazon affiliate links — I get a small commission if you buy through them"* is FTC-defensible (clear-and-conspicuous test), uses plain English, and fits the existing typography (matches the article's other `marginnote()` / `mn()` usage).

Discriminator unchanged from the prior pass: `?tag=danalol-20` query param + the one `amzn.to` shortlink. Plain `amazon.com` / `docs.aws.amazon.com` URLs without an affiliate tag are correctly left alone.

## Affected posts

- `2017-10-11-san-francisco-emergency-radio-setup.html.md.erb`
- `2017-10-12-how-this-site-works-p-2.html.md.erb`
- `2017-10-26-setting-up-a-handheld-radio-for-emergencies.html.md.erb`
- `2018-02-21-trip-report-big-sur.html.md.erb`
- `2018-07-21-buy-packs-with-amazon-coins-on-a-mac.html.md.erb`
- `2018-08-20-jump-into-my-passenger-seat.html.md.erb`
- `2020-04-16-the-most-boring-stream-on-twitch.html.md.erb`

## Test plan

- [x] Middleman build clean
- [ ] CF Pages PR preview deploy — eyeball one or two of the affected posts, confirm the marginnote renders in the margin near the top and reads naturally