### PR TITLE
tidy ERB helpers + drop current_article.url interpolations

### DIFF
--- a/helpers/dana_lol_helpers.rb
+++ b/helpers/dana_lol_helpers.rb
@@ -7,44 +7,62 @@ module DanaLolHelpers
   end
   alias_method :nt, :newthought
 
+  # Resolve a bare filename against the current article's URL. Absolute paths
+  # (leading /), full URLs (http(s)://), and data: URIs pass through unchanged.
+  def article_image_path(img_src)
+    return img_src if img_src.start_with?('/', 'http://', 'https://', 'data:')
+    "#{current_article.url}#{img_src}"
+  end
+
   def linked_image(img_src, alt_text = '')
-    link_to(image_tag(img_src, alt: alt_text), remove_file_extension(img_src), class: 'no-underline')
+    src = article_image_path(img_src)
+    link_to(image_tag(src, alt: alt_text), remove_file_extension(src), class: 'no-underline')
   end
 
   # used for images and other figures
-  def figure(img_src, alt_text = '')
+  def figure(img_src, alt_text = '', note: nil)
     content_tag(:figure) do
-      linked_image(img_src, alt_text)
+      body = linked_image(img_src, alt_text)
+      body += marginnote(note) if note
+      body
     end
   end
   alias_method :f, :figure
 
   # take up the whole screen
-  def full_figure(img_src, alt_text = '')
+  def full_figure(img_src, alt_text = '', note: nil)
     content_tag(:figure, class: 'fullwidth') do
-      linked_image(img_src, alt_text)
+      body = linked_image(img_src, alt_text)
+      body += marginnote(note) if note
+      body
     end
   end
   alias_method :ff, :full_figure
 
   # used for images and other figures that link to somewhere specific
-  def linked_figure(img_src, link, alt_text = '')
+  def linked_figure(img_src, link, alt_text = '', note: nil)
     content_tag(:figure) do
-      link_to(image_tag(img_src, alt: alt_text), link, class: 'no-underline')
+      body = link_to(image_tag(article_image_path(img_src), alt: alt_text), link, class: 'no-underline')
+      body += marginnote(note) if note
+      body
     end
   end
 
   # used for images and other figures that have no link
-  def nolink_figure(img_src, alt_text = '')
+  def nolink_figure(img_src, alt_text = '', note: nil)
     content_tag(:figure) do
-      image_tag(img_src, alt: alt_text)
+      body = image_tag(article_image_path(img_src), alt: alt_text)
+      body += marginnote(note) if note
+      body
     end
   end
 
   # used for images and other figures that have no link
-  def nolink_full_figure(img_src, alt_text = '')
+  def nolink_full_figure(img_src, alt_text = '', note: nil)
     content_tag(:figure, class: 'fullwidth') do
-      image_tag(img_src, alt: alt_text)
+      body = image_tag(article_image_path(img_src), alt: alt_text)
+      body += marginnote(note) if note
+      body
     end
   end
 
@@ -70,6 +88,19 @@ module DanaLolHelpers
     content_tag(:span, class: 'marginnote') { content || yield }
   end
   alias_method :mn, :marginnote
+
+  # Image inside a margin note, with optional caption and optional link target.
+  # Without `link:`, the image links to its own photo landing page (linked_image).
+  # With `link:`, the image links to the given URL (Amazon refs, external sites).
+  def margin_image(img_src, alt_text = '', caption: nil, link: nil)
+    img = if link
+      link_to(image_tag(article_image_path(img_src), alt: alt_text), link, class: 'no-underline')
+    else
+      linked_image(img_src, alt_text)
+    end
+    marginnote(caption ? img + caption : img)
+  end
+  alias_method :mi, :margin_image
 
   #TODO: maybe some day we will want this to take a block?
   def epigraph(content = nil, footer = nil)
@@ -106,4 +137,3 @@ module DanaLolHelpers
   end
 
 end
-

--- a/source/2017-09-29-elastic-beanstalk-enhanced-health-reporting.html.md.erb
+++ b/source/2017-09-29-elastic-beanstalk-enhanced-health-reporting.html.md.erb
@@ -12,7 +12,7 @@ ogp:
 
 When you start using AWS Elastic Beanstalk, you quickly learn that the Health dashboard is the best place to go to understand what is going on on your app. If you're anything like me, however, you might be disappointed to find some of the most useful fields are blank, like this:
 
-<%= nolink_full_figure "#{current_article.url}health-page-empty.png", 'a screenshot of an empty health dashboard' %>
+<%= nolink_full_figure 'health-page-empty.png', 'a screenshot of an empty health dashboard' %>
 
 The issue is that Elastic Beanstalk fetches the data for these tables _from the host machine_, as opposed to the container in which your app is running. In order to get the data to the Health dashboard, we will have to change a number of things first.
 
@@ -112,7 +112,7 @@ Check the following:
 
 If the answer to both of these is yes, you should be done! Visit the Health dashboard on your Elastic Beanstalk web console and you should be able to see all of the Enhanced Health data, like this:
 
-<%= nolink_full_figure "#{current_article.url}health-page-full.png", 'a screenshot of a heath dashboard with data' %>
+<%= nolink_full_figure 'health-page-full.png', 'a screenshot of a heath dashboard with data' %>
 
 Thanks for reading.
 I hope this helps you, and <%= link_to('please reach out to me', '/contact') %> with anything I could do to improve these instructions.

--- a/source/2017-10-11-san-francisco-emergency-radio-setup.html.md.erb
+++ b/source/2017-10-11-san-francisco-emergency-radio-setup.html.md.erb
@@ -15,9 +15,7 @@ ogp:
 
 _This article explains the rationale behind why you might want to add a radio to your emergency kit. If you're already convinced, skip to [part 2](/2017/10/26/setting-up-a-handheld-radio-for-emergencies/), which outlines which beginner radio to buy._
 
-<%= marginnote(
-  link_to(tag(:img, src: "#{current_article.url}uv-5r.jpg", alt: 'a photo of a handheld radio'), 'https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20', class: 'no-underline') + "You might want to add a [Baofeng UV-5R](https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20) (~$26) to your emergency kit"
-) %>
+<%= mi 'uv-5r.jpg', 'a photo of a handheld radio', link: 'https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20', caption: "You might want to add a [Baofeng UV-5R](https://smile.amazon.com/BaoFeng-UV-5R-Dual-Radio-Black/dp/B007H4VT7A?tag=danalol-20) (~$26) to your emergency kit" %>
 One of the best reasons to get into ham radio is for emergency preparedness. Living in San Francisco, there is always a chance there could be an earthquake, a tsunami, or another disaster. When the S hits the F, what are the odds your cell phone will work? Do you think you'll have access to the Internet?
 
 The truth is, almost every form of communication we make in the modern world requires some form of infrastructure. Phone calls, text messages, instant messages, even snail mail requires an unfathomable amount of little things to go just right.

--- a/source/2017-10-12-how-this-site-works-p-2.html.md.erb
+++ b/source/2017-10-12-how-this-site-works-p-2.html.md.erb
@@ -27,7 +27,7 @@ Nowadays that is horrible practice, and I want to follow best practices wherever
 
 So I know that I needed an off-the-shelf template for the visual design.
 I wanted something that followed best practices so I wouldn't have to figure them out, or embarrass myself by reinventing the wheel.
-<%= marginnote(link_to(image_tag("#{current_article.url}the-visual-display-of-quantitative-information.jpg", alt: 'an image of the cover of The Visual Display of Quantitative Information by Edward Tufte'), 'https://smile.amazon.com/Visual-Display-Quantitative-Information/dp/0961392142?tag=danalol-20', class: 'no-underline')) %>
+<%= mi 'the-visual-display-of-quantitative-information.jpg', 'an image of the cover of The Visual Display of Quantitative Information by Edward Tufte', link: 'https://smile.amazon.com/Visual-Display-Quantitative-Information/dp/0961392142?tag=danalol-20' %>
 
 <br>
 

--- a/source/2017-10-25-i-got-a-van.html.md.erb
+++ b/source/2017-10-25-i-got-a-van.html.md.erb
@@ -15,10 +15,8 @@ ogp:
 I got a van yesterday.
 It's a *1992 Dodge Roadtrek 190 Versatile*.
 
-<%= marginnote(
-  tag(:img, src: "#{current_article.url}layout.png", alt: 'the layout of a Roadtrek 190 Versatile') + "The internal layout. The front seats spin around, and the rear dinette converts to a queen-sized bed."
-) %>
-<%= figure "#{current_article.url}the-van.jpg", 'My van' %>
+<%= mi 'layout.png', 'the layout of a Roadtrek 190 Versatile', caption: "The internal layout. The front seats spin around, and the rear dinette converts to a queen-sized bed." %>
+<%= figure 'the-van.jpg', 'My van' %>
 
 Out of all of the vans in the Bay Area, why did I pick this one?
 Well, a ton of thought went into the decision, but I can provide a summary. 

--- a/source/2017-10-26-setting-up-a-handheld-radio-for-emergencies.html.md.erb
+++ b/source/2017-10-26-setting-up-a-handheld-radio-for-emergencies.html.md.erb
@@ -34,7 +34,7 @@ it's similar to finding a good FM radio station when you're traveling out-of-sta
 In any given geographic area, there are certain frequencies where people tend to hang out, or frequencies where emergency responders communicate.
 The trick is to pre-program your radio with these frequencies so you do not struggle to find someone during an emergency.
 
-<%= linked_figure("#{current_article.url}uv-5r-usb-cable.jpg", 'https://smile.amazon.com/Baofeng-Programming-Cable-BAOFENG-BF-888S/dp/B00CP0I474?tag=danalol-20', 'a photo of a Baofeng USB cable') %>
+<%= linked_figure('uv-5r-usb-cable.jpg', 'https://smile.amazon.com/Baofeng-Programming-Cable-BAOFENG-BF-888S/dp/B00CP0I474?tag=danalol-20', 'a photo of a Baofeng USB cable') %>
 
 The absolute easiest way to set up your radio is to use a USB cable to program your radio via your computer.
 <%= sn "If this seems too complex, [reach out to me](/contact) and I can sell you a pre-programmed radio." %>

--- a/source/2017-11-06-100-days-left-in-san-francisco.html.md.erb
+++ b/source/2017-11-06-100-days-left-in-san-francisco.html.md.erb
@@ -19,7 +19,7 @@ They were right that SF is an amazing place.
 It's beauty is something that needs to be seen firsthand.
 I will never tire of seeing the Golden Gate Bridge poke out above distant buildings, or the majestic views you can see as you walk across it, like this one (taken on my first visit to SF in 2013):
 
-<%= ff "#{current_article.url}golden-gate-bridge.jpg", 'Dana on the Golden Gate Bridge' %>
+<%= ff 'golden-gate-bridge.jpg', 'Dana on the Golden Gate Bridge' %>
 
 The problem is, everyone knows SF (and the rest of the Bay Area) is incredible.
 It's currently one of the most desirable places to live, and there's just not enough space for everyone.

--- a/source/2017-11-27-thanksgiving-in-santa-barbara.html.md.erb
+++ b/source/2017-11-27-thanksgiving-in-santa-barbara.html.md.erb
@@ -17,7 +17,7 @@ ogp:
 Me and the van went on our first major trip last weekend &mdash; from San Francisco to Santa Barbara &mdash; to visit my family for Thanksgiving.
 It was a weekend of firsts, so come along with me while I share the adventure with you.
 
-<%= ff "#{current_article.url}pano.jpg", 'my van in front of a mountainscape' %>
+<%= ff 'pano.jpg', 'my van in front of a mountainscape' %>
 
 The first major event that occurred was the odometer ticking over to 100k miles.
 I bought the van at 99.8k miles, so it wasn't very far into the 300 mile trip that I got to see all six digits change at once.
@@ -38,7 +38,7 @@ She warned me that the drive to her house was steep and windy... she wasn't kidd
 Situated in the [Los Padres National Forest](https://en.wikipedia.org/wiki/Los_Padres_National_Forest), her house feels like it's in the middle of nowhere.
 Dense forest, steep inclines, hairpin turns, and spectacular views surround her property.
 
-<%= f "#{current_article.url}santa-barbara.jpg", 'the view of Santa Barbara from Los Padres National Forest' %>
+<%= f 'santa-barbara.jpg', 'the view of Santa Barbara from Los Padres National Forest' %>
 
 It wasn't too much of a challenge to get there, however.
 The van took to the hills nicely, and I drove very carefully.
@@ -54,14 +54,14 @@ My aunt's boyfriend is a handyman and he helped me fix some little things that w
 One of those things was fixing the latch mechanism that keeps the hood closed, and to do that we had to visit a junkyard.
 We ended up getting thrown out ([long story](https://www.yelp.com/biz/steelhead-auto-recyclers-goleta?hrid=KNus4yTTI8ggFl5IvcEGLw)), but I did get to see a glimpse into my van's future:
 
-<%= f "#{current_article.url}junkyard.jpg", 'a 1990 Dodge Roadtrek in a junkyard' %>
+<%= f 'junkyard.jpg', 'a 1990 Dodge Roadtrek in a junkyard' %>
 
 When I wasn't working on the van and spending time with my family, I was exploring the area.
 My aunt took me to a really cool area called Lizard's Mouth, which is basically a huge playground of gigantic sandstone boulders overlooking the city of Santa Barbara.
 You can wander all you want, climb huge rocks and just feel like you've gone backwards in time.
 It was a really cool place, and I recommend it to anyone in the area!
 
-<%= ff "#{current_article.url}lizards-mouth.jpg", "Lizard's Mouth in Goleta, CA" %>
+<%= ff 'lizards-mouth.jpg', "Lizard's Mouth in Goleta, CA" %>
 
 That's pretty much it.
 Family, turkey, nature.
@@ -70,7 +70,7 @@ A great Thanksgiving weekend, all in all.
 On the way home I snapped this picture of the sunset over Pismo Beach.
 I could get used to this lifestyle, and I think I will!
 
-<%= f "#{current_article.url}sunset.jpg", 'sunset over Pismo Beach' %>
+<%= f 'sunset.jpg', 'sunset over Pismo Beach' %>
 
 Thanks for reading!
 If you would like to read future articles, you might want to like [my page on Facebook](https://www.facebook.com/adanalifeblog/).

--- a/source/2018-02-09-first-day-of-freedom.html.md.erb
+++ b/source/2018-02-09-first-day-of-freedom.html.md.erb
@@ -18,9 +18,7 @@ ogp:
 <%= epigraph('The only way to make sense out of change is to plunge into it, move with it, and join the dance.', 'Alan Watts') %>
 It’s Friday, and I’m not at work. It’s my first day of unemployment, and one of my last days in San Francisco.
 The van adventure begins in less than a week.
-<%= marginnote(
-  linked_image("#{current_article.url}corona-heights-sunrise.jpg", alt: 'a sunrise from Corona Heights Park') + "A sunrise from my final week in SF"
-) %>
+<%= mi 'corona-heights-sunrise.jpg', 'a sunrise from Corona Heights Park', caption: "A sunrise from my final week in SF" %>
 
 I know how exciting that sounds, but it’s been a very hard day.
 I woke up earlier than I would for work and started a task I dread: packing.

--- a/source/2018-02-14-and-we-re-off.html.md.erb
+++ b/source/2018-02-14-and-we-re-off.html.md.erb
@@ -19,10 +19,7 @@ ogp:
 Yesterday was my last day as a resident of San Francisco.
 It was a busy day: I still had to pack some stuff, move some furniture onto the street, clean up the apartment, and load up the van.
 
-<%= content_tag(:figure) do
-  linked_image("#{current_article.url}before-loading.jpg", 'Everything that was to be loaded into the van') +
-  mn("Everything I brought with me in the van.")
-end %>
+<%= f 'before-loading.jpg', 'Everything that was to be loaded into the van', note: "Everything I brought with me in the van." %>
 
 It's absurd how many things needed to be done to prep for this journey, it's like moving to two different places (the van and the storage container) while also packing for two vacations (camping and a road trip).
 I am a person who enjoys logistics but after four consecutive days of this I was physically and mentally exhausted.
@@ -39,7 +36,7 @@ All day yesterday I counted all of my lasts: my last time sleeping in my bed, my
 I drove to Santa Cruz where I had made arrangements to stay in the driveway of a lovely couple.
 I had stayed with them once before during a practice trip to Monterey, and it took a load off my mind to have my first night be somewhere I was familiar with.
 
-<%= f "#{current_article.url}santa-cruz-parking.jpg", 'The van in a driveway in Santa Cruz' %>
+<%= f 'santa-cruz-parking.jpg', 'The van in a driveway in Santa Cruz' %>
 
 The van itself is a mess, I haven't put anything away so to move around I have to move boxes from one available surface to another.
 I have tons of time to figure that out though, so I'm not worried about it.

--- a/source/2018-02-21-trip-report-big-sur.html.md.erb
+++ b/source/2018-02-21-trip-report-big-sur.html.md.erb
@@ -24,7 +24,7 @@ ogp:
 
 The first week is behind me, and I have returned to the land of reliable Internet and power.
 
-<%= f "#{current_article.url}limekiln-sunset.jpg", 'Sunset at Limekiln State Park, with a wave crashing on a rock' %>
+<%= f 'limekiln-sunset.jpg', 'Sunset at Limekiln State Park, with a wave crashing on a rock' %>
 
 I have so much to share with you, so I've broken it down into sections so you can skip to the things that interest you the most:
 
@@ -44,8 +44,8 @@ After spending [the first night of my van adventure](/2018/02/14/and-we-re-off/)
 Big Sur is a dramatic meeting of land and sea... a place where you can find stirring beaches, rugged mountains, serene redwood grottos, and steep rocky islets, all within view of one another.
 It is a magical place that has been left largely unmolested by humankind, and it was a spectacular way to start a trip across America.
 
-<%= f "#{current_article.url}limekiln-layover.jpg", 'A van parked in a turnout on Highway 1' %>
-<%= mn(linked_image("#{current_article.url}highway-one.jpg", 'A view of Highway 1 from my car') + "A typical view on Highway 1") %>
+<%= f 'limekiln-layover.jpg', 'A van parked in a turnout on Highway 1' %>
+<%= mi 'highway-one.jpg', 'A view of Highway 1 from my car', caption: "A typical view on Highway 1" %>
 
 Driving down Highway 1 alone is worth the trip, but my main destinations were [Pfeiffer Big Sur State Park](https://en.wikipedia.org/wiki/Pfeiffer_Big_Sur_State_Park) and [Limekiln State Park](https://en.wikipedia.org/wiki/Limekiln_State_Park), at which I had secured camping reservations months before.
 I had three nights reserved at each, and I didn't really know what to expect.
@@ -59,7 +59,7 @@ What I got was two very different camping experiences, an involuntary break from
 **Pfeiffer Big Sur State Park** is a beautiful park situated on the Big Sur River. It's the largest in the area, and features over 100 campsites, plus a few trails, an outdoor ampitheatre, a restaurant, and more. It is not, by any means, backcountry camping... it'd be a great place to take your family on a road trip, or bring your Cub Scout troop for a weekend. 
 
 When I made my reservations months ago, my research told me that the best spots were the ones on the river.
-<%= mn(linked_image("#{current_article.url}limekiln-campsite.jpg", 'A campsite at Limekiln') + "My campsite at Limekiln and home for 4 days") %>
+<%= mi 'limekiln-campsite.jpg', 'A campsite at Limekiln', caption: "My campsite at Limekiln and home for 4 days" %>
 I picked, somewhat arbitrarily, river campsite *#179*, and it was very pleasant.
 Two trees near the picnic table were perfect for my hammock, and the constant trickle of the river going by reminded me that I was, indeed, in the woods.
 Unfortunately a road on the other side of the river meant occasional cars driving by looking for their own campsites, which knocked me out of the sense of remoteness, especially after dark when their headlights would pierce through the trees.
@@ -68,13 +68,13 @@ I can't imagine what this park would feel like on a busy summer weekend; the cam
 Were I to stay again, I would opt for sites *#171* or *#174*, which had unusually spacious areas between the campsite and the river to explore and settle down in.
 
 **Limekiln State Park**, on the other hand, is something else entirely.
-<%= mn(linked_image("#{current_article.url}limekiln-entrance.jpg", 'The entrance to Limekiln State Park') + "Can you spot my van?") %>
+<%= mi 'limekiln-entrance.jpg', 'The entrance to Limekiln State Park', caption: "Can you spot my van?" %>
 When I first arrived I could tell from the tone of the ranger checking me in that I was in for a treat.
 My campsite, Ocean View *#1*, was the highest point on the ocean side of the park, with lots of privacy and its own unique view.
 I pulled up the dirt road and executed a smooth 15-point turn to have my back windows to the sea, and then I opened every curtain.
 It was the perfect campsite, and I had it for three more nights.
 
-<%= f "#{current_article.url}limekiln-campsite-view.JPG", 'The view from a campsite in Limekiln State Park' %>
+<%= f 'limekiln-campsite-view.JPG', 'The view from a campsite in Limekiln State Park' %>
 
 The back half of Limekiln has hiking trails and more campsites situated alongside a peaceful creek.
 If I come back, I'll definitely shoot for the ocean view campsite I had on this visit, but there were a couple campsites in the back that looked appealing.
@@ -88,7 +88,7 @@ The biggest challenge, at least at first, was the complete lack of cellphone rec
 When I was living in SF my phone was an extension of my body, and the number of ways it factored into my personal routines were countless.
 *Bored? Phone. Bathroom? Phone. Question? Phone. Lonely? Phone.*
 My habits all leaned on the Internet in some way, and I quickly had to adapt to a life without it.
-<%= mn(linked_image("#{current_article.url}pfeiffer-beach-hole.jpg", 'A hole in a rock at Pfeiffer Beach') + "Pfeiffer Beach") %>
+<%= mi 'pfeiffer-beach-hole.jpg', 'A hole in a rock at Pfeiffer Beach', caption: "Pfeiffer Beach" %>
 
 It would be difficult to describe my emotional state during this first week... I think I will need more context to truly understand it.
 What I can tell you is that in our modern lives we are given very little training in how to cope with changes this big.
@@ -102,7 +102,7 @@ No work emails to look at, no rent check to have to cover, no calendar events to
 As the reality of this sunk in (and it did take several days), I was able to find peace.
 I was surprised with how much free time I had when I had nothing to stress about.
 
-<%= f "#{current_article.url}me-at-mcway-falls.jpg", 'Me in front of Big Sur coastline near McWay Falls' %>
+<%= f 'me-at-mcway-falls.jpg', 'Me in front of Big Sur coastline near McWay Falls' %>
 
 
 ### <a name='physical-condition'>Physical Condition</a>
@@ -112,7 +112,7 @@ I have a lot more nicks and scratches than normal... between moving and camping,
 I got a few bruises and one pretty big welt on my forehead from when I walked into a cupboard door I forgot to close.
 My dust allergy isn't bothering me because I am spending almost all of my time outside.
 I've been using more sunscreen than I usually would, and every time I see poison oak I avoid it like the plague; I can't even imagine how quickly it would get over *everything* if I were to carry it into the van.
-<%= mn(linked_image("#{current_article.url}waterfall-over-log.jpg", 'Water falling over a log')) %>
+<%= mi 'waterfall-over-log.jpg', 'Water falling over a log' %>
 
 My hygiene is doing well too, I think!
 I don't think I smell bad yet, but I also don't think anyone would tell me if I did.
@@ -125,7 +125,7 @@ At Limekiln I was able to take my first shower in 6 days, and it was refreshing 
 ### <a name='meals'>Meals</a>
 
 This trip carried with it the challenge of not quite knowing how long I could keep my fridge cold, so I ate mainly non-perishable foods.
-<%= mn(linked_image("#{current_article.url}limekiln-fairyland.jpg", 'One of the many gorgeous redwood grottos in Big Sur')) %>
+<%= mi 'limekiln-fairyland.jpg', 'One of the many gorgeous redwood grottos in Big Sur' %>
 
 My meals included:
 
@@ -149,12 +149,12 @@ Who said being unemployed and homeless was a bad thing?
 
 As for hikes, I went hiking almost every day.
 Pfeiffer Big Sur had two trails that were pretty easy and ended in nice views.
-<%= mn(linked_image("#{current_article.url}valley-view.jpg", 'The view from Valley View Trail') + "The view from Valley View") %>
+<%= mi 'valley-view.jpg', 'The view from Valley View Trail', caption: "The view from Valley View" %>
 The first was **Valley View Trail**, which snaked its way along a ridge and ended in a nice view all the way down a V-shaped valley, all the way to the ocean.
 The second was **Buzzard's Roost Trail**, which was quite a bit longer and more challenging.
 I started pretty late in the day that day, so by the time I reached the summit the sun was starting to set.
 I didn't expect the view I got from the top... a gorgeous panorama from the mountains to the sea, and the ocean was nearly unrecognizable because the light reflecting off of it made it appear like it was made of pearl.
-<%= mn(linked_image("#{current_article.url}buzzards-roost.jpg", "The view from Buzzard's Roost Trail") + "The view from Buzzard's Roost") %>
+<%= mi 'buzzards-roost.jpg', "The view from Buzzard's Roost Trail", caption: "The view from Buzzard's Roost" %>
 
 Limekiln on the other hand, had some of the best hikes I have ever seen.
 Deep in the woods behind the beach there are four trails that all have unique and interesting destinations.
@@ -172,14 +172,14 @@ It creeps around a nearby mountain and pokes head out of the woods at opportune 
 
 You can click into any of these images to get super high resolution versions.
 
-<%= ff "#{current_article.url}limekiln-vista-pano.jpg", 'A vista on the unnamed Limekiln trail' %>
-<%= ff "#{current_article.url}pfeiffer-beach-pano.jpg", 'Pfeiffer Beach' %>
-<%= ff "#{current_article.url}limekiln-pano-2.JPG", 'A view of the beach section of Limekiln' %>
-<%= ff "#{current_article.url}partington-cove-pano.jpg", 'A secret cove a local told me about' %>
-<%= f "#{current_article.url}big-sur-coastline.jpg", 'Big Sur coastline' %>
-<%= f "#{current_article.url}mcway-falls.JPG", 'McWay Falls at dawn' %>
-<%= f "#{current_article.url}bixby-bridge.jpg", 'The iconic Bixby Bridge' %>
-<%= f "#{current_article.url}van-on-1.jpg", 'My van on Highway 1' %>
+<%= ff 'limekiln-vista-pano.jpg', 'A vista on the unnamed Limekiln trail' %>
+<%= ff 'pfeiffer-beach-pano.jpg', 'Pfeiffer Beach' %>
+<%= ff 'limekiln-pano-2.JPG', 'A view of the beach section of Limekiln' %>
+<%= ff 'partington-cove-pano.jpg', 'A secret cove a local told me about' %>
+<%= f 'big-sur-coastline.jpg', 'Big Sur coastline' %>
+<%= f 'mcway-falls.JPG', 'McWay Falls at dawn' %>
+<%= f 'bixby-bridge.jpg', 'The iconic Bixby Bridge' %>
+<%= f 'van-on-1.jpg', 'My van on Highway 1' %>
 
 Thank you for reading this and looking at my pictures!
 If you'd like to interact with me or just stay current with my updates, don't forget to [follow my Facebook page](https://www.facebook.com/adanalifeblog/).

--- a/source/2018-03-05-trip-report-central-coast.html.md.erb
+++ b/source/2018-03-05-trip-report-central-coast.html.md.erb
@@ -29,27 +29,27 @@ After being in the wilderness for my first week, I opted to spend my second week
 
 My first overnight spot after leaving my campsite at Limekiln was [San Luis Obispo](https://en.wikipedia.org/wiki/San_Luis_Obispo,_California), or _SLO_.
 I was only peripherally aware of SLO as a cool California city, but I didn't really know what to expect.
-<%= mn(linked_image("#{current_article.url}madonna-mountain-cows-2.JPG", 'Five cows on Madonna Mountain') + "Hey cows, mind if I use that trail you're standing on?") %>
+<%= mi 'madonna-mountain-cows-2.JPG', 'Five cows on Madonna Mountain', caption: "Hey cows, mind if I use that trail you're standing on?" %>
 I met up with a friend who lives there and he took me to the roof of a tall parking garage to give me the lay of the land.
 
 SLO has a cute trendy downtown area with lots of shopping and bars.
 The nearby California Polytechnic State University attracts a lot of young people, and the streets are clean and safe.
 It was a very nice place to visit in a van, and most of my overnight spots looked like this:
-<%= f "#{current_article.url}slo-parking.JPG", 'A Roadtrek parked on the street' %>
+<%= f 'slo-parking.JPG', 'A Roadtrek parked on the street' %>
 
 When I was looking at the map before I arrived, my eyes immediately were drawn to Cerro San Luis, or as the locals call it, _Madonna Mountain_.
 It erupts from the otherwise nearly-flat ground, and looms over the city.
 I knew I had to get up there, so I went up one evening at dusk.
 It was beautiful and had sweeping views of SLO and the surrounding areas.
 
-<%= ff "#{current_article.url}madonna-mountain-summit-pano.JPG", 'The view from the summit of Madonna Mountain' %>
+<%= ff 'madonna-mountain-summit-pano.JPG', 'The view from the summit of Madonna Mountain' %>
 
-<%= ff "#{current_article.url}madonna-mountain-pano.JPG", 'Bishop Peak during sunset' %>
+<%= ff 'madonna-mountain-pano.JPG', 'Bishop Peak during sunset' %>
 
 ### San Simeon
 
 When I first moved to California my grandmother told me I had to go to San Simeon and visit _Hearst Castle_.
-<%= mn(linked_image("#{current_article.url}hearst-from-ground.jpg", 'Heart Castle from a distance') + "The mountain-top castle looms far in the distance") %>
+<%= mi 'hearst-from-ground.jpg', 'Heart Castle from a distance', caption: "The mountain-top castle looms far in the distance" %>
 That was the first I'd ever heard of the place, but she stressed how much of an impact it had on her.
 I promised that I would go if I ever had the opportunity.
 Sadly she has since passed, but I am happy to say I was able to fulfill my promise.
@@ -59,42 +59,42 @@ Originally planned to be a modest camping lodge, Hearst worked with the virtuosi
 It's somewhat tricky to describe because the scale is unlike anything I have ever seen, but I took lots of pictures so hopefully that can give you an idea.
 All of the land you see in the pictures is actually part of the estate.
 
-<%= f "#{current_article.url}hearst-main-building.jpg", 'The main building at Heart Castle' %>
-<%= f "#{current_article.url}hearst-castle-study.JPG", "William Randolph Hearst's study" %>
-<%= ff "#{current_article.url}hearst-golden-statue-ground.jpg", 'The view from Heart Castle to the sea' %>
-<%= ff "#{current_article.url}hearst-castle-backyard.JPG", 'The view of the backyard of Hearst Castle' %>
+<%= f 'hearst-main-building.jpg', 'The main building at Heart Castle' %>
+<%= f 'hearst-castle-study.JPG', "William Randolph Hearst's study" %>
+<%= ff 'hearst-golden-statue-ground.jpg', 'The view from Heart Castle to the sea' %>
+<%= ff 'hearst-castle-backyard.JPG', 'The view of the backyard of Hearst Castle' %>
 
 On the way back I was able to see literally hundreds of elephant seals weaning their pups.
 What fun things you can find when you have nothing but free time!
-<%= f "#{current_article.url}elephant-seals.jpg", 'Elephant seals weaning pups' %>
+<%= f 'elephant-seals.jpg', 'Elephant seals weaning pups' %>
 
 ### Pismo Beach & Solvang
 
 On the way down the coast I stopped in a few cool places. 
 The first was [Pismo Beach](https://en.wikipedia.org/wiki/Pismo_Beach,_California), a gorgeous seaside community that has always sparked my imagination when I've driven through it.
 The best time to visit is at sunset, but I stopped by _Dinosaur Caves Park_, a pretty little cliff-top park that sadly does not have dinosaurs nor caves (though apparently it once had both).
-<%= ff "#{current_article.url}dinosaur-cave-park-pano.JPG", 'Dinosaur Caves Park' %>
+<%= ff 'dinosaur-cave-park-pano.JPG', 'Dinosaur Caves Park' %>
 
 Next stop was [Solvang](https://en.wikipedia.org/wiki/Solvang,_California), a small inland city that is as surreal as it is quaint.
 Founded by a group of Danes in 1911, they modeled all of the architecture around traditional Danish style.
 Walking around downtown it is easy to forget you're actually in California... it really feels like you somehow took an exit off the highway and ended up in Europe.
-<%= f "#{current_article.url}solvang-buildings.JPG", 'Colorful buildings on a street in Solvang' %>
-<%= f "#{current_article.url}solvang-windmill.JPG", 'Buildings in Solvang' %>
+<%= f 'solvang-buildings.JPG', 'Colorful buildings on a street in Solvang' %>
+<%= f 'solvang-windmill.JPG', 'Buildings in Solvang' %>
 
 ### Santa Barbara
 
 My main destination on this week was Santa Barbara<%= mn "Attentive readers might recall I went here on [my maiden voyage](/2017/11/27/thanksgiving-in-santa-barbara/)." %>, where my aunt Katie has a beautiful house nestled in the mountains.
 This was the first of what I call "medium-term destinations," which are places where friends or family have offered up their driveway, spare room, or guest house for me to use on my journey.
 Here I was able to charge my batteries, both literally and figuratively.
-<%= mn(linked_image("#{current_article.url}recharging-batteries.JPG", 'Many devices being recharged') + "Recharge all of the things!") %>
+<%= mi 'recharging-batteries.JPG', 'Many devices being recharged', caption: "Recharge all of the things!" %>
 
-<%= f "#{current_article.url}santa-barbara-mountainscape.jpg", 'Mountains behind Santa Barbara' %>
+<%= f 'santa-barbara-mountainscape.jpg', 'Mountains behind Santa Barbara' %>
 
 I stayed here for several days, catching up on the Internet, cleaning and repairing my van, and spending time with family.
 I spent only one day exploring... I went down to the water and walked around downtown Santa Barbara.
 
-<%= ff "#{current_article.url}santa-barbara-pier-pano.JPG", 'The view from Santa Barbara Pier' %>
-<%= ff "#{current_article.url}el-camini-cielo-pano.JPG", 'The view of Santa Barbara from the mountains' %>
+<%= ff 'santa-barbara-pier-pano.JPG', 'The view from Santa Barbara Pier' %>
+<%= ff 'el-camini-cielo-pano.JPG', 'The view of Santa Barbara from the mountains' %>
 
 Thank you for reading this and looking at my pictures.
 As a reminder, if you'd like to interact with me or just stay current with my updates, you can [follow my Facebook page](https://www.facebook.com/adanalifeblog/).

--- a/source/2018-03-07-photos-behind-the-scenes-at-the-price-is-right.html.md.erb
+++ b/source/2018-03-07-photos-behind-the-scenes-at-the-price-is-right.html.md.erb
@@ -22,13 +22,13 @@ A friend of mine works on the creative team on the acclaimed TV game show [The P
 He invited me to visit him at the CBS studios in Hollywood, so obviously I took him up on it.
 Here are some of the photos I took while I was there.
 
-<%= ff "#{current_article.url}onstage-pano.png", 'the stage at the Price is Right' %>
-<%= f "#{current_article.url}behind-the-wheel.JPG", 'behind the famous Price is Right wheel' %>
-<%= f "#{current_article.url}from-the-stage.JPG", 'the view from the stage at The Price is Right' %>
-<%= f "#{current_article.url}me-with-money.JPG", 'Dana in front of some dollar signs' %>
-<%= f "#{current_article.url}games.JPG", 'stored Price is Right games' %>
-<%= f "#{current_article.url}old-school.JPG", 'a Price is Right mural featuring Bob Barker' %>
-<%= f "#{current_article.url}control-room.png", 'the control room at The Price is Right' %>
+<%= ff 'onstage-pano.png', 'the stage at the Price is Right' %>
+<%= f 'behind-the-wheel.JPG', 'behind the famous Price is Right wheel' %>
+<%= f 'from-the-stage.JPG', 'the view from the stage at The Price is Right' %>
+<%= f 'me-with-money.JPG', 'Dana in front of some dollar signs' %>
+<%= f 'games.JPG', 'stored Price is Right games' %>
+<%= f 'old-school.JPG', 'a Price is Right mural featuring Bob Barker' %>
+<%= f 'control-room.png', 'the control room at The Price is Right' %>
 
 Thank you for visiting!
 While you're here, check out the coolest thing I've made: [The Most Boring Stream on Twitch](/2020/04/16/the-most-boring-stream-on-twitch/).

--- a/source/2018-03-13-trip-report-los-angeles.html.md.erb
+++ b/source/2018-03-13-trip-report-los-angeles.html.md.erb
@@ -28,40 +28,40 @@ Had this famously van-friendly city turned a corner?
 It turns out that if you pay attention to parking rules and avoid drawing too much attention to yourself, LA is still very friendly to van-dwellers.
 
 The first time I visited LA as an adult was during a work outing.
-<%= mn(linked_image("#{current_article.url}hollywood-sign-with-me.JPG", 'Dana in front of the Hollywood Sign') + "I guess I'm a full-time tourist now, might as well embrace it") %>
+<%= mi 'hollywood-sign-with-me.JPG', 'Dana in front of the Hollywood Sign', caption: "I guess I'm a full-time tourist now, might as well embrace it" %>
 We rented a bungalow near **Venice Beach** and immediately I was in love.
 The wide inviting beach, the laid back culture, the always-sunny weather, the sunsets, the iconic pier and board-walk, it's magnetic for a friendly bum like myself.
 I had to scour the area for places I could park (many streets have a 7-foot height limit), but eventually I discovered a quiet neighborhood in which I stayed almost every night.
 I chatted with several residents, and they were extremely kind to me.
-<%= mn(linked_image("#{current_article.url}venice-beach-sky.JPG", 'The sky above Venice Beach') + "Average day in Venice, CA") %>
+<%= mi 'venice-beach-sky.JPG', 'The sky above Venice Beach', caption: "Average day in Venice, CA" %>
 It is out of respect for them that I wont list exactly where I was, but aspiring visitors should find little trouble finding a place to park overnight.
 
-<%= f "#{current_article.url}venice-beach-pier.JPG", 'A view from under the Venice Beach pier' %>
-<%= ff "#{current_article.url}venice-boardwalk-pano.JPG", 'A view of the Venice Beach boardwalk' %>
+<%= f 'venice-beach-pier.JPG', 'A view from under the Venice Beach pier' %>
+<%= ff 'venice-boardwalk-pano.JPG', 'A view of the Venice Beach boardwalk' %>
 
 Waking up to the sea air, walking the beach all the way to Santa Monica, exploring the mansion-lined canals, and watching the sun dip into the sea were some of the ways I spent my days as a Venice "resident."
 I miss it already!
 
-<%= ff "#{current_article.url}venice-sunset-pano.JPG", 'The sunset behind Venice Beach' %>
+<%= ff 'venice-sunset-pano.JPG', 'The sunset behind Venice Beach' %>
 
 One of the first excursions I took outside of Venice was to the **[Getty Center](https://en.wikipedia.org/wiki/Getty_Center)**.
 Situated high on the Santa Monica foothills, the Getty complex features art, outdoor gardens, beautiful architecture, and sweeping panoramic views of the city of Los Angeles.
 It's also free, which is great, but parking is $10-$15.
-<%= mn(linked_image("#{current_article.url}getty-statue.JPG", 'A sexy statue on the roof of the Getty Center') + "Current mood") %>
+<%= mi 'getty-statue.JPG', 'A sexy statue on the roof of the Getty Center', caption: "Current mood" %>
 
-<%= f "#{current_article.url}getty-sunset.JPG", 'Sunset at the Getty Center' %>
-<%= ff "#{current_article.url}getty-pano.JPG", 'The view from the Getty Center' %>
+<%= f 'getty-sunset.JPG', 'Sunset at the Getty Center' %>
+<%= ff 'getty-pano.JPG', 'The view from the Getty Center' %>
 
 I asked some friends what museums I should visit, and when someone suggested the **Museum of Death**, from the name alone I knew I had to check it out.
 I do have a macabre-leaning side of me, but I'll admit I wasn't quite prepared for what was in store.
 I enjoyed the awesome collection of death-related miscellania... letters and paintings from serial killers, antique coroners' equipment, skulls and weapons.
-<%= mn(linked_image("#{current_article.url}museum-of-death.JPG", "The entrance to the Museum of Death") + "Unfortunately, no photography is allowed at the Museum of Death") %>
+<%= mi 'museum-of-death.JPG', "The entrance to the Museum of Death", caption: "Unfortunately, no photography is allowed at the Museum of Death" %>
 What I wasn't prepared for was the gruesome pictures from crime scenes, autopsies, car crashes, etc.
 They're scattered throughout the galleries in such a way that they are tricky to avoid.
 Reader beware, this museum is not for the squeamish or the faint of heart!
 I didn't leave the museum feeling scarred for life, but it was a lot to process before lunch.
 
-<%= f "#{current_article.url}hollywood-sign.JPG", 'The famous Hollywood Sign' %>
+<%= f 'hollywood-sign.JPG', 'The famous Hollywood Sign' %>
 
 I think my favorite excursion was hiking to the top of the Hollywood sign.
 Sure, they don't let you get close to the sign anymore (trust me, I tried and got yelled at), but you can get _behind_ sign, and that's almost as good.
@@ -69,7 +69,7 @@ I started at **Lake Hollywood Park** and hiked the five-mile trail to the summit
 It was a pretty clear day and the views were beautiful all the way up.
 I definitely recommend this to anyone with time to kill in LA.
 
-<%= ff "#{current_article.url}hollywood-sign-pano.JPG", 'A view from the hike to the Hollywood Sign' %>
+<%= ff 'hollywood-sign-pano.JPG', 'A view from the hike to the Hollywood Sign' %>
 
 I did a ton of other things, but I didn't take pictures of all of them.
 I had my first experience in a sensory deprivation tank, which was equal parts boring and cool.
@@ -78,7 +78,7 @@ I [toured The Price is Right studios](/2018/03/07/photos-behind-the-scenes-at-th
 I spent a lot of time in East LA, which is apparently very trendy.
 I rode in a swan boat in **Echo Lake Park**, I spent a couple nights right on the **Silver Lake Reservoir**, I ate at countless hipster cafés and restaurants.
 
-<%= f "#{current_article.url}silver-lake-van.JPG", 'My van near Silver Lake Reservoir' %>
+<%= f 'silver-lake-van.JPG', 'My van near Silver Lake Reservoir' %>
 
 Oh!
 One last thing that I did get a picture of.
@@ -88,7 +88,7 @@ Entering that hanger was a jaw-dropping moment for me, it's just massive!
 And it's been to space and back!
 And it's right there for you to visit!
 
-<%= ff "#{current_article.url}endeavor-pano.JPG", 'The Space Shuttle Endeavor!' %>
+<%= ff 'endeavor-pano.JPG', 'The Space Shuttle Endeavor!' %>
 
 Thank you for reading!
 I really appreciate you taking the time out of your day to visit my site.

--- a/source/2018-03-20-trip-report-san-diego.html.md.erb
+++ b/source/2018-03-20-trip-report-san-diego.html.md.erb
@@ -30,19 +30,19 @@ It wasn't the weather that made me stay.
 In fact, it was raining when I arrived, and it stayed uncharacteristically rainy for the first half of my visit.
 Instead, it was the lovely home that I got to stay in, and the wonderful family I got to be a part of for almost two weeks.
 I got to hang out with my friend, his wife, their two beautiful daughters (ages 4 and 7), and their incredible golden retrievers.
-<%= mn(linked_image("#{current_article.url}captain-at-pool.jpg", 'Captain the dog near a pool')) %>
+<%= mi 'captain-at-pool.jpg', 'Captain the dog near a pool' %>
 
-<%= f "#{current_article.url}coach-in-blanket.JPG", 'Coach the dog cozy in a blanket' %>
+<%= f 'coach-in-blanket.JPG', 'Coach the dog cozy in a blanket' %>
 
 The girls loved using my van as a clubhouse, and I set up my hammocks in their lawn for them to play on.
 During the day everyone went off to school and work. 
 I spent this time sitting by a placid pool, soaking up sun and reliable Internet, with the dogs to keep me company.
-<%= mn(linked_image("#{current_article.url}coach-at-door.JPG", 'Coach the dog greeting me at the door')) %>
+<%= mi 'coach-at-door.JPG', 'Coach the dog greeting me at the door' %>
 
 And honestly, that's how I spent most of my days... recharging my batteries, staying still, taking daily showers, and spending time with my surrogate family.
 I mean, how could you resist these wonderful puppies?
 
-<%= f "#{current_article.url}captain-in-lawn.jpg", 'Captain the dog standing in a lawn' %>
+<%= f 'captain-in-lawn.jpg', 'Captain the dog standing in a lawn' %>
 
 Of course, I did do other stuff too!
 I went for walks around a nearby golf course and many beaches, I went sea kayaking with a friend in La Jolla...
@@ -52,40 +52,40 @@ I went for walks around a nearby golf course and many beaches, I went sea kayaki
 
 ...and of course, I ate astoundingly delicious Mexican food.
 
-<%= f "#{current_article.url}get-these-chips.JPG", 'Dana wearing a hat that says "get these chips away from me" with some chips' %>
+<%= f 'get-these-chips.JPG', 'Dana wearing a hat that says "get these chips away from me" with some chips' %>
 
 
 But the thing I documented the best was the [San Diego Zoo](https://en.wikipedia.org/wiki/San_Diego_Zoo), and the sister *Safari Park*.
 These are world-class zoos that by themselves are worth a trip down to San Diego.
 I spent two days there (one at the Zoo and one at the Safari Park), and took countless pictures, the best of which I've included below.
 
-<%= ff "#{current_article.url}butterfly-2.jpg", 'a butterfly' %>
-<%= ff "#{current_article.url}funny-crocodiles.jpg", 'funny looking crocodiles' %>
-<%= f "#{current_article.url}elephant.jpg", 'an elephant' %>
-<%= ff "#{current_article.url}flamingos.jpg", 'many flamingos' %>
-<%= f "#{current_article.url}polar-bear-in-shade.jpg", 'a polar bear napping in shade' %>
-<%= f "#{current_article.url}funny-monkey.jpg", 'a funny looking monkey' %>
-<%= ff "#{current_article.url}butterfly-blue.jpg", 'a blue butterfly' %>
-<%= ff "#{current_article.url}hippos-surfacing-2.jpg", 'hippos' %>
-<%= f "#{current_article.url}lions-sleeping.jpg", 'lions sleeping' %>
-<%= ff "#{current_article.url}crocodile.jpg", 'a crocodile' %>
-<%= ff "#{current_article.url}polar-bear-closeup.jpg", 'polar bear sleeping' %>
-<%= f "#{current_article.url}monkeys.jpg", 'some monkeys' %>
-<%= ff "#{current_article.url}pig.jpg", 'some pigs' %>
-<%= f "#{current_article.url}orangutans.jpg", 'some orangutans' %>
-<%= f "#{current_article.url}polar-bear-butt.jpg", 'a polar bear butt' %>
-<%= ff "#{current_article.url}butterfly-brown.jpg", 'a brown butterfly' %>
-<%= f "#{current_article.url}tiger-tail.jpg", 'the tail of a tiger poking out over a rock' %>
-<%= ff "#{current_article.url}polar-bears-sleeping.jpg", 'sleeping polar bears' %>
-<%= ff "#{current_article.url}hippo.jpg", 'a hippo' %>
-<%= f "#{current_article.url}lion-in-cage.jpg", 'a lion in a cage' %>
-<%= ff "#{current_article.url}rhino.jpg", 'a rhino' %>
-<%= f "#{current_article.url}butterfly-green.jpg", 'a green butterfly' %>
-<%= ff "#{current_article.url}scared-monkey.jpg", 'a scared-looking monkey' %>
-<%= ff "#{current_article.url}sleepy-gorilla.jpg", 'a sleepy gorilla' %>
-<%= f "#{current_article.url}sleepy-lemurs.jpg", 'some lazy lemurs' %>
-<%= ff "#{current_article.url}tiger.jpg", 'a tiger' %>
-<%= ff "#{current_article.url}safari-park-pano.JPG", 'The San Diego Safari Park' %>
+<%= ff 'butterfly-2.jpg', 'a butterfly' %>
+<%= ff 'funny-crocodiles.jpg', 'funny looking crocodiles' %>
+<%= f 'elephant.jpg', 'an elephant' %>
+<%= ff 'flamingos.jpg', 'many flamingos' %>
+<%= f 'polar-bear-in-shade.jpg', 'a polar bear napping in shade' %>
+<%= f 'funny-monkey.jpg', 'a funny looking monkey' %>
+<%= ff 'butterfly-blue.jpg', 'a blue butterfly' %>
+<%= ff 'hippos-surfacing-2.jpg', 'hippos' %>
+<%= f 'lions-sleeping.jpg', 'lions sleeping' %>
+<%= ff 'crocodile.jpg', 'a crocodile' %>
+<%= ff 'polar-bear-closeup.jpg', 'polar bear sleeping' %>
+<%= f 'monkeys.jpg', 'some monkeys' %>
+<%= ff 'pig.jpg', 'some pigs' %>
+<%= f 'orangutans.jpg', 'some orangutans' %>
+<%= f 'polar-bear-butt.jpg', 'a polar bear butt' %>
+<%= ff 'butterfly-brown.jpg', 'a brown butterfly' %>
+<%= f 'tiger-tail.jpg', 'the tail of a tiger poking out over a rock' %>
+<%= ff 'polar-bears-sleeping.jpg', 'sleeping polar bears' %>
+<%= ff 'hippo.jpg', 'a hippo' %>
+<%= f 'lion-in-cage.jpg', 'a lion in a cage' %>
+<%= ff 'rhino.jpg', 'a rhino' %>
+<%= f 'butterfly-green.jpg', 'a green butterfly' %>
+<%= ff 'scared-monkey.jpg', 'a scared-looking monkey' %>
+<%= ff 'sleepy-gorilla.jpg', 'a sleepy gorilla' %>
+<%= f 'sleepy-lemurs.jpg', 'some lazy lemurs' %>
+<%= ff 'tiger.jpg', 'a tiger' %>
+<%= ff 'safari-park-pano.JPG', 'The San Diego Safari Park' %>
 
 As always, thank you for visiting and looking at my pictures.
 Come visit [my Facebook page](https://www.facebook.com/adanalifeblog/) and let me know which pictures were your favorites!

--- a/source/2018-03-25-trip-report-joshua-tree.html.md.erb
+++ b/source/2018-03-25-trip-report-joshua-tree.html.md.erb
@@ -23,11 +23,11 @@ ogp:
 }
 %>
 
-<%= f "#{current_article.url}road.jpg", 'a road in Joshua Tree National Park' %>
+<%= f 'road.jpg', 'a road in Joshua Tree National Park' %>
 
 After leaving my comfortable poolside retreat in [San Diego](/2018/03/20/trip-report-san-diego/), I headed straight for the desert.
 My destination was [Joshua Tree National Park](https://en.wikipedia.org/wiki/Joshua_Tree_National_Park), one of the youngest National Parks.
-<%= mn(linked_image("#{current_article.url}quail-3.jpg", 'a quail in Joshua Tree National Parl')) %>
+<%= mi 'quail-3.jpg', 'a quail in Joshua Tree National Parl' %>
 
 I had my sights on **Hidden Valley Campground** but I arrived there in the early afternoon, and it was obvious from the line of cars to get in that it'd be unlikely I'd be able to stay in the park at all.
 I asked the ranger if it was worth driving into the park to try, and he told me dozens of people had tried and he watched them return unsuccessfully.
@@ -37,17 +37,17 @@ To find a place to sleep in the desert that night, I turned to [Boondockers Welc
 By luck I was able to find a host deep in the desert 25 miles north of Joshua Tree who very generously let me stay in their backyard on short notice.
 I arrived at dusk and left before first light.
 
-<%= f "#{current_article.url}sunrise-2.jpg", 'sunrise over Hidden Valley in Joshua Tree National Park' %>
+<%= f 'sunrise-2.jpg', 'sunrise over Hidden Valley in Joshua Tree National Park' %>
 
 As the sun rose over the desert mountains I arrived at Hidden Valley Campground, which my research had told me the best campground in the park.
-<%= mn(linked_image("#{current_article.url}campsite-from-side.jpg", 'my van at campsite 40')) %>
+<%= mi 'campsite-from-side.jpg', 'my van at campsite 40' %>
 This campground is first-come, first-served, so I decided to wait at the entrance for people to leave.
 A friendly camper informed me the real trick is to find campsites with only one car and ask if they would be willing to share with me, so I drove into the campground and started to ask around.
 After a couple awkward interactions I found a friendly couple from Oakland, who happened to be staying for as long as I was.
 We split the cost of the campsite and I had friends and a home base for the next 3 nights.
 
-<%= f "#{current_article.url}campsite-40-2.jpg", 'my van at campsite 40 at Hidden Valley Campground in Joshua Tree National Park' %>
-<%= f "#{current_article.url}hidden-valley-rocks.JPG", 'some rocks at Joshua Tree National Park' %>
+<%= f 'campsite-40-2.jpg', 'my van at campsite 40 at Hidden Valley Campground in Joshua Tree National Park' %>
+<%= f 'hidden-valley-rocks.JPG', 'some rocks at Joshua Tree National Park' %>
 
 <%= nt "So what's" %>
 the deal with this place?
@@ -59,69 +59,69 @@ It's feels like you're on another planet.
 There's the eponymous trees, which reach out to the sky with their many arms.
 They dot the barren desert and make it feel like a forest.
 
-<%= f "#{current_article.url}mill-trail.jpg", 'a pretty trail surrounded by joshua trees' %>
+<%= f 'mill-trail.jpg', 'a pretty trail surrounded by joshua trees' %>
 
 Bulbous boulders litter the landscape.
-<%= mn(linked_image("#{current_article.url}round-rocks.jpg", 'more rocks at Joshua Tree National Park')) %>
+<%= mi 'round-rocks.jpg', 'more rocks at Joshua Tree National Park' %>
 They look like something out of a Dr. Seuss book, and climbers from all around the world visit to climb them.
 This is also the reason the campground was so packed... there's tons of places to climb and boulder within walking distance.
 
 My new campsite friends and I scrambled to the top of one... it was a little intimidating, but the view from the top and the satisfaction was worth it (though my hands are sweating typing this).
 
-<%= f "#{current_article.url}view-from-top-3.JPG", 'view from the top of Cyclops Rock' %>
-<%= ff "#{current_article.url}desert-pano-2.JPG", 'a view of a desert in Joshua Tree National Park' %>
-<%= ff "#{current_article.url}intersection-rock-climbers.jpg", 'climbers at the top of Intersection Rock in Joshua Tree National Park' %>
+<%= f 'view-from-top-3.JPG', 'view from the top of Cyclops Rock' %>
+<%= ff 'desert-pano-2.JPG', 'a view of a desert in Joshua Tree National Park' %>
+<%= ff 'intersection-rock-climbers.jpg', 'climbers at the top of Intersection Rock in Joshua Tree National Park' %>
 
 Every day I was there I went on a different fabulous hike.
-<%= mn(linked_image("#{current_article.url}cactus.jpg", 'a cactus in Joshua Tree National Park')) %>
+<%= mi 'cactus.jpg', 'a cactus in Joshua Tree National Park' %>
 The first was *Ryan Mountain*, which is a pretty strenuous 3-mile hike to the top of a mountain.
 The view from the top is expansive, but the satisfaction came from finishing the hike and not the vistas.
 
-<%= f "#{current_article.url}desert-2.jpg", 'a view of the desert in Joshua Tree National Park' %>
-<%= ff "#{current_article.url}mt-ryan-pano.JPG", 'a view from Ryan Mountain' %>
+<%= f 'desert-2.jpg', 'a view of the desert in Joshua Tree National Park' %>
+<%= ff 'mt-ryan-pano.JPG', 'a view from Ryan Mountain' %>
 
 *Lost Horse Mine* was a really neat 4-mile trail that leads to an abandoned mine.
 The machinery is still there for you to look at and imagine what it was like when it was running.
 
-<%= f "#{current_article.url}lost-horse-trail-2.jpg", 'a trail in Joshua Tree National Park' %>
-<%= ff "#{current_article.url}mine-pano.JPG", 'a view of an abandoned mine' %>
-<%= f "#{current_article.url}lost-horse-trail.jpg", 'another trail in Joshua Tree National Park' %>
+<%= f 'lost-horse-trail-2.jpg', 'a trail in Joshua Tree National Park' %>
+<%= ff 'mine-pano.JPG', 'a view of an abandoned mine' %>
+<%= f 'lost-horse-trail.jpg', 'another trail in Joshua Tree National Park' %>
 
 On one of the hottest days I hiked to *Skull Rock*, an appropriately-named rock formation.
 It was very close to the **Jumbo Rocks Campground**, which seemed like a nice place to stay and I will consider it next time I'm in the area.
 
-<%= f "#{current_article.url}skull-rock.jpg", 'Skull Rock' %>
+<%= f 'skull-rock.jpg', 'Skull Rock' %>
 
 The *Hidden Valley Trail* is right near the campground at which I was staying.
 Hidden inside a ring of rocks you can find a lush valley, so cleverly disguised cattle rustlers apparently hid cattle inside it.
 It's a very fun area to explore; to beat the crowds I went at sunrise and had the whole valley to myself.
 
-<%= f "#{current_article.url}hidden-valley.jpg", 'rocks surrounding Hidden Valley' %>
-<%= f "#{current_article.url}sunrise-rocks.JPG", 'rocks at sunrise' %>
+<%= f 'hidden-valley.jpg', 'rocks surrounding Hidden Valley' %>
+<%= f 'sunrise-rocks.JPG', 'rocks at sunrise' %>
 
 Finally, I hiked out to *Barker Dam*, which was used by early cattle ranchers in the area.
-<%= mn(linked_image("#{current_article.url}engine-closest.jpg", 'a view of a rusted out engine in the desert')) %>
+<%= mi 'engine-closest.jpg', 'a view of a rusted out engine in the desert' %>
 The trail has many other interesting things nearby, like an abandoned mill, rusted-out cars, and some ancient petroglyphs.
 
-<%= f "#{current_article.url}abandoned-car-2.jpg", 'an abandoned car in the desert' %>
-<%= ff "#{current_article.url}building-pano.JPG", 'a view of an abandoned building' %>
+<%= f 'abandoned-car-2.jpg', 'an abandoned car in the desert' %>
+<%= ff 'building-pano.JPG', 'a view of an abandoned building' %>
 
 
 All-in-all Joshua Tree is one of the coolest places I have ever been.
 If you're a climber or a hiker, you have to check this place out.
 Pictures don't really do it any justice, but I've done my best to include a selection to give you an idea about what it's like.
 
-<%= f "#{current_article.url}collapsing-tree.jpg", 'a gigantic collapsing Joshua tree' %>
-<%= f "#{current_article.url}pretty-view-2.jpg", 'a view from a vista in Joshua Tree National Park' %>
-<%= f "#{current_article.url}cyclops-rock.jpg", 'a cool looking rock in Joshua Tree National Park' %>
-<%= f "#{current_article.url}intersection-rock.JPG", 'climbers at the top of Intersection Rock' %>
-<%= ff "#{current_article.url}van-on-road-pano.JPG", 'my van on the main road in Joshua Tree National Park' %>
-<%= f "#{current_article.url}joshua-tree-forest.jpg", 'a veritable forest of Joshua trees' %>
-<%= f "#{current_article.url}van-in-lot.jpg", 'my van in a parking lot in Joshua Tree National Park' %>
-<%= f "#{current_article.url}pretty-view.jpg", 'a pretty vista in Joshua Tree National Park' %>
-<%= f "#{current_article.url}ryan-mountain-trail.JPG", 'a trail in Joshua Tree National Park' %>
-<%= ff "#{current_article.url}salton-sea-pano.JPG", 'a view of the Salton Sea from Joshua Tree National Park' %>
-<%= f "#{current_article.url}van-on-road.JPG", 'my van on a road in Joshua Tree National Park' %>
+<%= f 'collapsing-tree.jpg', 'a gigantic collapsing Joshua tree' %>
+<%= f 'pretty-view-2.jpg', 'a view from a vista in Joshua Tree National Park' %>
+<%= f 'cyclops-rock.jpg', 'a cool looking rock in Joshua Tree National Park' %>
+<%= f 'intersection-rock.JPG', 'climbers at the top of Intersection Rock' %>
+<%= ff 'van-on-road-pano.JPG', 'my van on the main road in Joshua Tree National Park' %>
+<%= f 'joshua-tree-forest.jpg', 'a veritable forest of Joshua trees' %>
+<%= f 'van-in-lot.jpg', 'my van in a parking lot in Joshua Tree National Park' %>
+<%= f 'pretty-view.jpg', 'a pretty vista in Joshua Tree National Park' %>
+<%= f 'ryan-mountain-trail.JPG', 'a trail in Joshua Tree National Park' %>
+<%= ff 'salton-sea-pano.JPG', 'a view of the Salton Sea from Joshua Tree National Park' %>
+<%= f 'van-on-road.JPG', 'my van on a road in Joshua Tree National Park' %>
 
 Thank you for reading!
 I really appreciate you taking the time out of your day to visit my site.

--- a/source/2018-04-01-a-trip-back-to-san-francisco.html.md.erb
+++ b/source/2018-04-01-a-trip-back-to-san-francisco.html.md.erb
@@ -25,7 +25,7 @@ ogp:
 After my wonderful stay in [Joshua Tree](/2018/03/25/trip-report-joshua-tree) I pointed my van back North.
 At this point I had traveled from San Francisco all the way down the California coast, but I already wanted to go back.
 I drove through LA and spent another night at my favorite spot in Venice.
-<%= mn(linked_image("#{current_article.url}venice-canals.jpg", 'the Venice Canals') + "The Venice area of LA has these beautiful man-made canals that you can wander around.") %>
+<%= mi 'venice-canals.jpg', 'the Venice Canals', caption: "The Venice area of LA has these beautiful man-made canals that you can wander around." %>
 
 Why go back to San Francisco?
 It's not that I was ready to end the trip; this was actually part of the plan all along.
@@ -41,7 +41,7 @@ I also left a large amount of toiletries, which in my haste to pack I had just d
 
 So instead of visiting my storage locker, I went back to visit my friends.
 As a former resident, my parking permit was valid, so I returned to my neighborhood 
-<%= mn(linked_image("#{current_article.url}van-on-panhandle.jpg", 'my Roadtrek parked on the Panhandle in San Francisco')) %>
+<%= mi 'van-on-panhandle.jpg', 'my Roadtrek parked on the Panhandle in San Francisco' %>
 and lived on the street for a week.
 I stopped by my old work and surprised everyone ("are you done already?"), and I hit up some of my favorite restaurants.
 
@@ -49,12 +49,12 @@ Several of my friends -- who all happened to be funemployed at the same time -- 
 We drove out to Point Reyes (perhaps my very favorite place to see nature in the Bay Area) and took a long hike out to a beach and back.
 It was a real treat to savor a nice day with a bunch of people who were all "supposed to" be at work.
 
-<%= f "#{current_article.url}friends-on-beach-2.jpg", 'my friends walking along the beach' %>
+<%= f 'friends-on-beach-2.jpg', 'my friends walking along the beach' %>
 
 I could feel myself getting back into my old habits though, so I capped my stay at one week.
 On the last day, I drove out to the Golden Gate Bridge to get the iconic "I used to live in SF and now I live in a van" picture... I think it turned out great!
 
-<%= ff "#{current_article.url}van-at-golden-gate-bridge.jpg", 'my Roadtrek in front of the Golden Gate Bridge' %>
+<%= ff 'van-at-golden-gate-bridge.jpg', 'my Roadtrek in front of the Golden Gate Bridge' %>
 
 Thanks for reading.
 Next stop, [Yosemite](/2018/04/06/trip-report-yosemite)!

--- a/source/2018-04-06-trip-report-yosemite.html.md.erb
+++ b/source/2018-04-06-trip-report-yosemite.html.md.erb
@@ -22,20 +22,20 @@ ogp:
 }
 %>
 
-<%= f "#{current_article.url}bridalveil-fall.jpg", 'a view of Bridalveil Fall from a distance' %>
+<%= f 'bridalveil-fall.jpg', 'a view of Bridalveil Fall from a distance' %>
 
 After swinging through [San Francisco](/2018/04/01/a-trip-back-to-san-francisco) for a little bit of comfort, I got back on the road.
 My next stop was one of my very favorite places on the planet, [Yosemite National Park](https://en.wikipedia.org/wiki/Yosemite_National_Park).
 
 If you've never been to Yosemite it can be tricky to understand why people love it so much.
-<%= mn(linked_image("#{current_article.url}me-at-nevada-fall.jpg", 'the author standing in front of Nevada Fall')) %>
+<%= mi 'me-at-nevada-fall.jpg', 'the author standing in front of Nevada Fall' %>
 To paint a picture of the experience, imagine standing next to a massive wall of stone.
 You can walk right up to the wall and put your hand on it.
 Above you it towers taller than any building you have ever seen -- over 270 stories.
 Behind you is a wall of similar scale, and pouring off these walls in every direction are waterfalls.
 It makes you feel really small, and you immediately know it's a special place.
 
-<%= f "#{current_article.url}valley-view-iphone.jpg", 'the famous Tunnel View in Yosemite' %>
+<%= f 'valley-view-iphone.jpg', 'the famous Tunnel View in Yosemite' %>
 
 I spent three nights camping at the _Upper Pines Campground_.
 It's a popular campground and it was full, even in April.
@@ -47,7 +47,7 @@ If you're coming to Yosemite to get away from people, you might want to consider
 Since the campground is right in Yosemite Valley, I spent the first day walking around the valley floor.
 In my wandering I managed to get this uncommon perspective: the broad side of the famous Half Dome.
 
-<%= ff "#{current_article.url}flat-side-of-half-dome-pano.jpg", 'a view of the broad side of Half Dome from Yosemite Valley' %>
+<%= ff 'flat-side-of-half-dome-pano.jpg', 'a view of the broad side of Half Dome from Yosemite Valley' %>
 
 Even though the park was very crowded, it was easy to find quiet spots to be alone.
 I found a spot near a waterfall and tried to remain in the moment.
@@ -62,13 +62,13 @@ It's quite a hike, alternating between switchbacks and stairs for the entire 5-m
 You get up close and personal with two different waterfalls (Upper and Lower Fall) and the view from the top is extraordinary.
 Below there were hundreds of other people hiking, exploring, and looking upward at the falls.
 
-<%= ff "#{current_article.url}yosemite-valley.jpg", 'a panoramic view of Yosemite Valley taken near the top of Lower Fall' %>
+<%= ff 'yosemite-valley.jpg', 'a panoramic view of Yosemite Valley taken near the top of Lower Fall' %>
 
 If I were to do it again, I would start earlier in the morning, because it got very crowded.
 I would also take less gear... my big Canon 5D DSLR has never felt heavier!
 
 <%= mn "Yeah you gotta climb all the way up there..." %>
-<%= f "#{current_article.url}upper-yosemite-falls.jpg", 'a view of Upper Yosemite Fall from below' %>
+<%= f 'upper-yosemite-falls.jpg', 'a view of Upper Yosemite Fall from below' %>
 
 On the final day I set my sights on an even bigger hike.
 This one is also focused around two waterfalls, in this case [Vernal Fall and Nevada Fall](https://www.nps.gov/yose/planyourvisit/vernalnevadatrail.htm).
@@ -80,8 +80,8 @@ I was envious of those who remembered to pack trek poles... There were definitel
 At the top of the Mist Trail there is a huge flat granite you can lean out over the falls and look down.
 
 <%= mn "See how tiny the people are?" %>
-<%= f "#{current_article.url}vernal-fall-from-above.jpg", 'a view of the top of Vernal Fall from near the John Muir Trail' %>
-<%= f "#{current_article.url}mist-trail-view.jpg", 'looking back on the Mist Trail in Yosemite National Park' %>
+<%= f 'vernal-fall-from-above.jpg', 'a view of the top of Vernal Fall from near the John Muir Trail' %>
+<%= f 'mist-trail-view.jpg', 'looking back on the Mist Trail in Yosemite National Park' %>
 
 This was a very long hike, one of the longest I would do on the entire van trip.
 I hiked alone for 11 miles with 3,000ft of elevation gain.
@@ -91,9 +91,9 @@ There were times where I thought to myself _"that's probably enough, I've seen s
   <iframe width="560" height="315" src="https://www.youtube.com/embed/El0JaSfX-cc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 <% end %>
 
-<%= f "#{current_article.url}fall-2.jpg", 'the water below Nevada Fall in Yosemite National Park' %>
-<%= f "#{current_article.url}distant-fall.jpg", 'a view of a far-away waterfall in Yosemite National Park' %>
-<%= f "#{current_article.url}nevada-fall-with-liberty-cap.jpg", 'a view of Nevada Fall and Liberty Cap' %>
+<%= f 'fall-2.jpg', 'the water below Nevada Fall in Yosemite National Park' %>
+<%= f 'distant-fall.jpg', 'a view of a far-away waterfall in Yosemite National Park' %>
+<%= f 'nevada-fall-with-liberty-cap.jpg', 'a view of Nevada Fall and Liberty Cap' %>
 
 After coming back to my campsite I scarfed down a quick meal and promptly fell asleep.
 In the morning I would be leaving familiar territory -- indeed, leaving California for the first time on the trip -- and heading into the desert.

--- a/source/2018-05-09-photos-that-time-i-saw-pink.html.md.erb
+++ b/source/2018-05-09-photos-that-time-i-saw-pink.html.md.erb
@@ -21,12 +21,12 @@ If that wasn't enough, I was given a backstage pass, which let me watch the show
 
 I don't know her music that well but I had a blast, caught a stick from her drummer, and had a once-in-a-lifetime experience!
 
-<%= f "#{current_article.url}banner.jpg", 'Dana in front of a concert banner' %>
-<%= f "#{current_article.url}up-close.jpg", 'P!NK performs up close' %>
+<%= f 'banner.jpg', 'Dana in front of a concert banner' %>
+<%= f 'up-close.jpg', 'P!NK performs up close' %>
 
 Here's the backstage pass and the stick that I caught.
 
-<%= f "#{current_article.url}stick-and-pass.jpg", 'a drum stick and backstage pass' %>
+<%= f 'stick-and-pass.jpg', 'a drum stick and backstage pass' %>
 
 Her flying rig was elaborate and jaw-dropping.
 
@@ -36,7 +36,7 @@ Her flying rig was elaborate and jaw-dropping.
 
 Eminem wasn't there to perform, but they did have a gigantic inflatable version of him.
 
-<%= f "#{current_article.url}eminem.jpg", 'a giant inflatable Eminem dummy' %>
+<%= f 'eminem.jpg', 'a giant inflatable Eminem dummy' %>
 
 <% iframe_wrapper do %>
   <iframe width="560" height="315" src="https://www.youtube.com/embed/z91hqgRf8oE?rel=0&amp;controls=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>

--- a/source/2018-06-30-map-adventure-so-far.html.md.erb
+++ b/source/2018-06-30-map-adventure-so-far.html.md.erb
@@ -17,6 +17,6 @@ ogp:
 
 Just wanted to post a quick update showing where I've gone so far:
 
-<%= f "#{current_article.url}map.png", 'a map showing the journey so far' %>
+<%= f 'map.png', 'a map showing the journey so far' %>
 
 For (slightly) more frequent updates and bonus content, [follow me on social media](https://www.facebook.com/adanalifeblog/).

--- a/source/2018-07-21-buy-packs-with-amazon-coins-on-a-mac.html.md.erb
+++ b/source/2018-07-21-buy-packs-with-amazon-coins-on-a-mac.html.md.erb
@@ -26,9 +26,7 @@ Keep reading, or [click here](#guide) to jump to the step-by-step guide.
 
 ### About Amazon Coins
 
-<%= marginnote(
-  link_to(tag(:img, src: "#{current_article.url}coin.jpg", alt: 'a picture of an Amazon Coin (this is copyright Amazon)'), 'http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20', class: 'no-underline')
-) %>
+<%= mi 'coin.jpg', 'a picture of an Amazon Coin (this is copyright Amazon)', link: 'http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20' %>
 
 Hearthstone is a great game but it can be very expensive.
 Luckily there is a way to save money on packs using something called [Amazon Coins](http://www.amazon.com/dp/B0096E8DSM/?tag=danalol-20).
@@ -51,18 +49,18 @@ If asked things during the install process, you can use the default settings.
 You will have to add a security exception for Bluestacks, as it requires a kernel extension.
 If the install fails for this reason, go to System Preferences → Security and Privacy → General, and click "Allow".
 
-<%= nolink_figure "#{current_article.url}system-preferences.jpg", 'a screenshot of Mac System Preferences' %>
+<%= nolink_figure 'system-preferences.jpg', 'a screenshot of Mac System Preferences' %>
 
 Open up Bluestacks and go through the initial setup wizard, logging in with your Google account.
 When it's up and running, go to "My Apps" and open the Browser app which looks like this:
 
-<%= nolink_figure "#{current_article.url}browser.jpg", 'the icon of the Bluestacks browser app' %>
+<%= nolink_figure 'browser.jpg', 'the icon of the Bluestacks browser app' %>
 
 In the browser, search Google for "Amazon Appstore for Android" and download the installer.
 A small download icon will appear in the top left corner of Bluestacks.
 Click on it and drag downward until you see this:
 
-<%= nolink_figure "#{current_article.url}amazon-apk.jpg", 'the way to open the Amazon Appstore App APK' %>￼
+<%= nolink_figure 'amazon-apk.jpg', 'the way to open the Amazon Appstore App APK' %>￼
 
 Now open the Amazon APK file and install the Amazon Appstore app.
 Open the Amazon Appstore and log in to your Amazon account.
@@ -73,7 +71,7 @@ Open the Store and select the item you want to purchase.
 
 At the payment screen, you will get a new prompt, asking you to once again log in to your Amazon account.
 
-<%= nolink_figure "#{current_article.url}hearthstone-payment-screen.jpg", 'the Amazon Coins payment screen' %>￼
+<%= nolink_figure 'hearthstone-payment-screen.jpg', 'the Amazon Coins payment screen' %>￼
 
 Log in and complete the purchase.
 Congrats, you have now bought Hearthstone packs at a discount!

--- a/source/2018-09-24-disaster.html.md.erb
+++ b/source/2018-09-24-disaster.html.md.erb
@@ -22,7 +22,7 @@ ogp:
 }
 %>
 
-<%= f "#{current_article.url}second-tow-truck.jpg", 'a Roadtrek on a flatbed tow truck' %>
+<%= f 'second-tow-truck.jpg', 'a Roadtrek on a flatbed tow truck' %>
 
 After a nice visit to Thomas Jefferson's [Monticello](https://en.wikipedia.org/wiki/Monticello), my **check engine** light went on.
 There was no unusual noise or behavior when the light turned on, so I continued on my way to Appomattox, Virginia.
@@ -57,7 +57,7 @@ An angry driver behind me passes me as I search for a safe place to pull over.
 I turn down a dark rural road and come to a stop outside of a house.
 The kind of house that does not exude hospitality.
 No cell phone service.
-<%= mn(linked_image("#{current_article.url}great-smoky-mountains.jpg" , 'some mountains covered in fog at Great Smoky Mountains National Park') + "The Great Smoky Mountains. Every second broken down was a second I might be spending here!") %>
+<%= mi 'great-smoky-mountains.jpg', 'some mountains covered in fog at Great Smoky Mountains National Park', caption: "The Great Smoky Mountains. Every second broken down was a second I might be spending here!" %>
 
 After some time I work up the courage to go knock on the door of the house.
 I introduce myself to the confused couple who answered the door, and while explaining my situation I manage to get some cell service.
@@ -73,12 +73,12 @@ The tow truck driver leaves and I settle in to the not-quite-ideal location for 
 
 I'm optimistic that I'll be back on the road again tomorrow.
 
-<%= f "#{current_article.url}dropping-off-van.jpg", 'a Roadtrek being dropped off at a mechanics parking lot' %>
+<%= f 'dropping-off-van.jpg', 'a Roadtrek being dropped off at a mechanics parking lot' %>
 
 
 ## Day Two
 
-<%= mn(linked_image("#{current_article.url}route-map.jpg" , 'a map showing the route I took')) %>
+<%= mi 'route-map.jpg', 'a map showing the route I took' %>
 
 I get up 15 minutes before the mechanic opens and leave a voicemail.
 They call me back promptly and they agree to fit me in right away.
@@ -100,7 +100,7 @@ I'm in the middle of nowhere and very far from "home."
 Even though I've just paid a couple hundred dollars on a repair, my van is still broken and immobile.
 It's 85°f (30°C), I'm parked in direct sunlight, and battery that powers all of my electronics is dead.
 
-<%= f "#{current_article.url}van-at-first-mechanic.jpg", 'a Roadtrek with its hood open' %>
+<%= f 'van-at-first-mechanic.jpg', 'a Roadtrek with its hood open' %>
 
 So I set to work calling other local mechanics.
 I needed an electrical diagnosis, which was time-consuming and only to be attempted by a mechanic comfortable with electronics.
@@ -113,7 +113,7 @@ The new plan is to get another tow, two-and-a-half hours to the Southeast, all t
 There I could find a plethora of mechanics.
 My reluctant tow truck driver picked up my van and we set off.
 
-<%= f "#{current_article.url}second-tow-truck-2.jpg", 'a Roadtrek being picked up by a flatbed tow truck' %>
+<%= f 'second-tow-truck-2.jpg', 'a Roadtrek being picked up by a flatbed tow truck' %>
 
 He dropped me off in a parking lot in Greensboro, NC and I tried to get some sleep.
 I'd be getting up early to call more mechanics tomorrow.
@@ -130,7 +130,7 @@ Six hours later they had figured out what was wrong.
 The [battery isolator](https://en.wikipedia.org/wiki/Battery_isolator), which takes power from the alternator and passes it to my van's two batteries, was burnt out.
 Practically incinerated.
 
-<%= f "#{current_article.url}burnt-isolator.jpg", 'a very-burnt Roadtrek battery isolator' %>
+<%= f 'burnt-isolator.jpg', 'a very-burnt Roadtrek battery isolator' %>
 
 Well, okay!
 There's the problem!
@@ -142,7 +142,7 @@ After 48 hours of being immobile, I was finally free.
 
 ## Conclusions
 
-<%= mn(linked_image("#{current_article.url}brochure.jpg" , 'a brochure for Great Smoky Mountains National Park')) %>
+<%= mi 'brochure.jpg', 'a brochure for Great Smoky Mountains National Park' %>
 
 Living in a van is a pretty great experience -- that is, until something goes wrong.
 Being able to choose your backyard every day can be exciting, freeing, and glamorous, but when you have an issue that renders the vehicle inoperable, the van becomes a prison.
@@ -162,7 +162,7 @@ Instead I tried my best to remain calm, to keep looking for new solutions, and t
 By remaining calm, being patient, and acting quickly, I was eventually able to make it to my campsite at the Great Smoky Mountains on time.
 Another adventure behind me, and many new ones on the road in front of me.
 
-<%= f "#{current_article.url}van-at-campsite.jpg" , 'a Roadtrek at Smokemont Campground in Great Smoky Mountain National Park' %>
+<%= f 'van-at-campsite.jpg' , 'a Roadtrek at Smokemont Campground in Great Smoky Mountain National Park' %>
 
 Thanks for reading!
 If you enjoyed reading this, please consider sharing it with someone you think might enjoy it too.

--- a/source/2018-09-26-map-adventure-so-far-v2.html.md.erb
+++ b/source/2018-09-26-map-adventure-so-far-v2.html.md.erb
@@ -17,7 +17,7 @@ ogp:
 Since everyone enjoyed [the last map of the adventure](/2018/06/30/map-adventure-so-far/), I've updated the map to reflect the journey thus far.
 When this map was created I was outside of Dallas, TX, having come from the East.
 
-<%= f "#{current_article.url}map.png", 'a map showing the journey so far' %>
+<%= f 'map.png', 'a map showing the journey so far' %>
 
 There's one last leg this map is missing... from Texas to Los Angeles, and then from LA to San Francisco (where I sold the van).
 I plan on making a better, more complete, and ideally interactive map in the future.

--- a/source/2019-01-13-post-adventure-summary.html.md.erb
+++ b/source/2019-01-13-post-adventure-summary.html.md.erb
@@ -28,7 +28,7 @@ I traveled alone across the country, [from San Diego to Maine and back](/2018/09
 I experienced so many great things, and I have so much to share with you!
 
 <%= mn("This photo, for instance, was taken at sunrise while in Acadia National Park") %>
-<%= f "#{current_article.url}cruise-ship-sunrise.jpg", 'a cruise ship in front of a sunrise from Mount Desert Island, Maine' %>
+<%= f 'cruise-ship-sunrise.jpg', 'a cruise ship in front of a sunrise from Mount Desert Island, Maine' %>
 
 Let's be honest here: articles on this site are few and far between.
 Early on in the trip I decided to spend more time adventuring and less writing articles.
@@ -43,7 +43,7 @@ These I suspect will be some of the most popular articles because they appeal to
 
 *Also, I have released a tremendous amount of dashcam footage, [check it out](/2018/08/20/jump-into-my-passenger-seat/)!*
 
-<%= mn(linked_image("#{current_article.url}waterlilies.jpg", 'some waterlilies in Acadia National Park')) %>
+<%= mi 'waterlilies.jpg', 'some waterlilies in Acadia National Park' %>
 
 <strike>
 I also have a _Frequently Asked Questions_ section in the works.

--- a/source/2020-04-15-tripbot-the-adventure-robot.html.md.erb
+++ b/source/2020-04-15-tripbot-the-adventure-robot.html.md.erb
@@ -15,7 +15,7 @@ ogp:
 
 ---
 
-<%= mn(linked_image("#{current_article.url}screencap.jpg", 'a screencap from dashcam footage showing a geyser erupting from a parking lot in Yellowstone National Park')) %>
+<%= mi 'screencap.jpg', 'a screencap from dashcam footage showing a geyser erupting from a parking lot in Yellowstone National Park' %>
 For the past year I've been running [a slow-tv art project](/2020/04/16/the-most-boring-stream-on-twitch/).
 It's comprised of an immense trove of my own dashcam footage, plus a custom chatbot to interact with the footage.
 I'm writing this to announce that I've made the [source code to Tripbot](https://github.com/adanalife/tripbot) publicly available.
@@ -39,7 +39,7 @@ Future commands include `!map` (to display a map on the stream) and `!temperatur
 
 ## General architecture
 
-<%= f "#{current_article.url}infra-diagram.png", 'a technical diagram showing how services interact' %>
+<%= f 'infra-diagram.png', 'a technical diagram showing how services interact' %>
 
 The project is composed of two main components: a bot process and a custom [VLC](https://en.wikipedia.org/wiki/VLC_media_player) process.
 They are both written in Golang, and they talk to one another over HTTP.

--- a/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
+++ b/source/2020-04-16-the-most-boring-stream-on-twitch.html.md.erb
@@ -55,7 +55,7 @@ I would save all of my dashcam footage and make it available online, sort of a [
 This would allow me to "passively" generate content while simply driving.
 I didn't know if anyone would watch it, but I knew the idea was at the very least unique.
 
-<%= f "#{current_article.url}cycling-animation.gif", 'a looping animation of various still frames from dashcam footage' %>
+<%= f 'cycling-animation.gif', 'a looping animation of various still frames from dashcam footage' %>
 
 
 ## 250+ Hours of Footage


### PR DESCRIPTION
## Summary
- **`helpers/dana_lol_helpers.rb`** — adds `article_image_path` so bare filenames auto-resolve against the current article URL; adds `margin_image` (aliased `mi`) for image-in-margin-note with `caption:` / `link:` kwargs; extends figure helpers with a `note:` kwarg.
- **All 25 article files** — migrated to the cleaner syntax. Before/after examples:

  ```diff
  - <%= f "#{current_article.url}santa-barbara.jpg", 'the view of Santa Barbara' %>
  + <%= f 'santa-barbara.jpg', 'the view of Santa Barbara' %>

  - <%= mn(linked_image("#{current_article.url}highway-one.jpg", 'A view of Highway 1 from my car') + "A typical view on Highway 1") %>
  + <%= mi 'highway-one.jpg', 'A view of Highway 1 from my car', caption: "A typical view on Highway 1" %>

  - <%= marginnote(link_to(image_tag("#{current_article.url}book.jpg", alt: '...'), 'https://amazon...', class: 'no-underline')) %>
  + <%= mi 'book.jpg', '...', link: 'https://amazon...' %>

  - <%= content_tag(:figure) do
  -   linked_image("#{current_article.url}before-loading.jpg", 'alt') +
  -   mn("Everything I brought with me in the van.")
  - end %>
  + <%= f 'before-loading.jpg', 'alt', note: "Everything I brought with me in the van." %>
  ```

- **`#{current_article.url}` interpolations dropped:** 179 occurrences across 25 files.
- **Two intentional rendered-output diffs** (verified via build-time HTML comparison after normalizing the `mn-N`/`sn-N` auto-incrementing IDs):
  1. `2018/02/09/first-day-of-freedom` — fixes a pre-existing latent bug where `linked_image('...', alt: 'foo')` was passing `{alt: 'foo'}` as the positional `alt_text` arg, rendering as `alt-alt="foo"`. Now correctly `alt="foo"`.
  2. `2017/10/25/i-got-a-van` — the `layout.png` margin-note image now links to its photo landing page like every other image on the site (originally used `tag(:img, ...)` without a link wrapper — an outlier).
- All other diffs are noise: `mn-N` / `sn-N` ID renumbering (global counter) and lorem-ipsum / build-timestamp variation in `feed.xml`, `sitemap.xml`, `article-template`, `page/3`.

## Test plan
- [ ] CF Pages preview builds cleanly
- [ ] Spot-check a handful of trip-report articles in the preview against current prod for visual parity (Big Sur, LA, Joshua Tree have the most `mi` calls)
- [ ] Confirm the two intentional diffs (linked layout.png margin image on i-got-a-van; correct alt on first-day-of-freedom)