### PR TITLE
fix: repair 3 broken external links surfaced by lychee

### DIFF
--- a/data/faq.yml
+++ b/data/faq.yml
@@ -95,7 +95,7 @@ questions:
       <p>
       The fridge built in my Roadtrek could be powered in three ways: shore power, the coach battery, and propane.
       With propane I could keep it cold when I was holding still for several days, but I rarely used this feature.
-      Instead, I found a fancy <a href="https://www.engelcoolers.com/mr040f-u1-mr040f-u1-ac-dc-fridge-freezer.html">marine fridge</a> on sale and used that for everything.
+      Instead, I found a fancy <a href="https://engelcoolers.com/collections/powered-fridge-freezers">marine fridge</a> on sale and used that for everything.
       This way I could keep things cold with only battery power, and boy could that thing get cold!
       </p>
     short: fridge

--- a/data/faq.yml
+++ b/data/faq.yml
@@ -37,7 +37,7 @@ questions:
       <a href="/2018/09/26/map-adventure-so-far-v2/map" class="no-underline"><img src="/2018/09/26/map-adventure-so-far-v2/map.png" alt="a map showing the journey so far"></a>
       I <a href="/2018/02/14/and-we-re-off/">started in San Francisco</a> in mid-February.
       I made my way down the California coast, stopping by <a href="/2018/02/21/trip-report-big-sur/">Big Sur</a>, <a href="/2018/03/05/trip-report-central-coast/">the central coast cities</a>, and <a href="/2018/03/13/trip-report-los-angeles/">LA</a>, before stopping in <a href="/2018/03/20/trip-report-san-diego/">San Diego</a>.
-      I then went to <a href=""></a> before coming <a href="/2018/04/01/a-trip-back-to-san-francisco/"><em>back</em></a> to SF.
+      I then went to <a href="/2018/03/25/trip-report-joshua-tree/">Joshua Tree</a> before coming <a href="/2018/04/01/a-trip-back-to-san-francisco/"><em>back</em></a> to SF.
       Next was <a href="/2018/04/06/trip-report-yosemite/">Yosemite</a>, after which I headed for the desert.
       </p>
       <p>

--- a/source/2018-02-21-trip-report-big-sur.html.md.erb
+++ b/source/2018-02-21-trip-report-big-sur.html.md.erb
@@ -133,7 +133,7 @@ My meals included:
  * Strawberries, raspberries, and Samoas Girl Scout Cookies
  * Berries and greek yogurt
  * Cheese, salami, hummus, and crackers
- * Chocolate [Soylent](http://amzn.to/2CAci9w)
+ * Chocolate [Soylent](https://amzn.to/4324MDj) (#ad)
 
 In the next few months I would like to learn more van-friendly recipes, especially ones that use only a single pot.
 

--- a/source/2018-03-25-trip-report-joshua-tree.html.md.erb
+++ b/source/2018-03-25-trip-report-joshua-tree.html.md.erb
@@ -33,7 +33,7 @@ I had my sights on **Hidden Valley Campground** but I arrived there in the early
 I asked the ranger if it was worth driving into the park to try, and he told me dozens of people had tried and he watched them return unsuccessfully.
 This was the busiest park I'd been to yet, and I'd have to rethink my strategy.
 
-To find a place to sleep in the desert that night, I turned to [Boondockers Welcome](http://boondockerswelcome.com/), a service where RV-friendly hosts can offer their driveways to wandering vagrants like myself.
+To find a place to sleep in the desert that night, I turned to [Boondockers Welcome](https://www.boondockerswelcome.com/), a service where RV-friendly hosts can offer their driveways to wandering vagrants like myself.
 By luck I was able to find a host deep in the desert 25 miles north of Joshua Tree who very generously let me stay in their backyard on short notice.
 I arrived at dusk and left before first light.
 


### PR DESCRIPTION
## Summary

- **big-sur Soylent affiliate** — `amzn.to/2CAci9w` redirected to a dead Amazon product (B01NBIF6WS, 503). Swapped for a current Chocolate Soylent listing using the same `danalol-20` affiliate tag; added `(#ad)` marker per the convention from #218.
- **joshua-tree Boondockers Welcome** — `http://boondockerswelcome.com/` (bare host) returns 404; the site only responds at `https://www.boondockerswelcome.com/`. URL bumped.
- **FAQ Engel marine fridge** — the specific MR040F-U1 product page is discontinued (404). Repointed to the powered fridge/freezer collection page, which serves the same illustrative purpose ("a fancy marine fridge").
- **FAQ route anchor** — separate audit item (polish-tier "Empty anchor in `data/faq.yml`"): the empty `<a href=""></a>` between San Diego and "back to SF" now links to Joshua Tree, which was the stop that went there.

Local `ENV=test middleman build` passes; rendered HTML in `build/` confirms all four hrefs land at the new URLs.

## Test plan

- [ ] CF Pages preview link renders all four pages without console errors
- [ ] Click each updated link from the preview, confirm 200