### PR TITLE
fix: promote big-sur and faq section headings from h3 to h2

### DIFF
--- a/source/2018-02-21-trip-report-big-sur.html.md.erb
+++ b/source/2018-02-21-trip-report-big-sur.html.md.erb
@@ -38,7 +38,7 @@ I have so much to share with you, so I've broken it down into sections so you ca
 
 Also if you're reading this on mobile, make sure to tap the "⊕" icons when you see them!
 
-### <a name='overview'>Overview</a>
+## <a name='overview'>Overview</a>
 
 After spending [the first night of my van adventure](/2018/02/14/and-we-re-off/) in Santa Cruz, I drove down Highway 1 to spend my first week in [Big Sur](https://en.wikipedia.org/wiki/Big_Sur).
 Big Sur is a dramatic meeting of land and sea... a place where you can find stirring beaches, rugged mountains, serene redwood grottos, and steep rocky islets, all within view of one another.
@@ -52,7 +52,7 @@ I had three nights reserved at each, and I didn't really know what to expect.
 What I got was two very different camping experiences, an involuntary break from the comforts of technology, and a whole lot of alone time.
 
 
-### <a name='places-slept'>Places Slept</a>
+## <a name='places-slept'>Places Slept</a>
 
 <%= epigraph("...sequoias, kings of their race, growing close together like grass in a meadow, poised their brave domes and spires in the sky three hundred feet above the ferns and the lilies that enameled the ground; towering serene through the long centuries, preaching God's forestry fresh from heaven.", 'John Muir, 1897') %>
 
@@ -82,7 +82,7 @@ Campsite *#22* had an awesome view of the intersection of two forest creeks, and
 For more privacy, site *#29* was tucked against a rock face and had its own "private" trails behind it (leading to the power and water infrastructure buildings for the campground).
 That one seemed like a nice place to stay because it's also right in the middle of the campground, so you'd be close to everything.
 
-### <a name='mental-condition'>Mental Condition</a>
+## <a name='mental-condition'>Mental Condition</a>
 
 The biggest challenge, at least at first, was the complete lack of cellphone reception.
 When I was living in SF my phone was an extension of my body, and the number of ways it factored into my personal routines were countless.
@@ -105,7 +105,7 @@ I was surprised with how much free time I had when I had nothing to stress about
 <%= f 'me-at-mcway-falls.jpg', 'Me in front of Big Sur coastline near McWay Falls' %>
 
 
-### <a name='physical-condition'>Physical Condition</a>
+## <a name='physical-condition'>Physical Condition</a>
 
 Physically, I'm doing quite well.
 I have a lot more nicks and scratches than normal... between moving and camping, I had small cuts on half my fingers just a couple days in.
@@ -122,7 +122,7 @@ In fact, every part of my body has probably itched at some point in the last wee
 At Limekiln I was able to take my first shower in 6 days, and it was refreshing even though it cost me 9 quarters and cut off after exactly 6 minutes.
 
 
-### <a name='meals'>Meals</a>
+## <a name='meals'>Meals</a>
 
 This trip carried with it the challenge of not quite knowing how long I could keep my fridge cold, so I ate mainly non-perishable foods.
 <%= mi 'limekiln-fairyland.jpg', 'One of the many gorgeous redwood grottos in Big Sur' %>
@@ -138,7 +138,7 @@ My meals included:
 In the next few months I would like to learn more van-friendly recipes, especially ones that use only a single pot.
 
 
-### <a name='leisure-time'>Leisure Time</a>
+## <a name='leisure-time'>Leisure Time</a>
 
 For this trip, this section might as well be called "*Hikes,*" but before I get into that I'll go over some of the things I did to keep myself busy.
 I wrote in a journal, I lounged in my hammock, I scanned for ham radio chatter, I read a great deal of a book, I organized my van, I watched downloaded TV on my laptop, I went over photos, I worked on this blog article, I planned my next days... am I missing anything?
@@ -168,7 +168,7 @@ It creeps around a nearby mountain and pokes head out of the woods at opportune 
 
 
 
-### <a name='photos'>More Photos</a>
+## <a name='photos'>More Photos</a>
 
 You can click into any of these images to get super high resolution versions.
 

--- a/source/faq.html.md.erb
+++ b/source/faq.html.md.erb
@@ -8,7 +8,7 @@ ogp:
 Something you want to know?
 [Ask me here](/ama)!
 
-### Table of Contents
+## Table of Contents
 <ul>
   <% data.faq.questions.each do |faq| %>
     <% next unless faq.published %>
@@ -21,7 +21,7 @@ Something you want to know?
 </ul>
 
 
-### Questions and Answers
+## Questions and Answers
 
 <ul>
   <% data.faq.questions.each do |faq| %>


### PR DESCRIPTION
## Summary

Lighthouse's [`heading-order`](https://developer.chrome.com/docs/lighthouse/accessibility/heading-order/) check flagged big-sur and faq during the 2026-05-06 pre-launch audit: the layout emits `<h1 class='title'>` for the page title, then the content jumped directly to `<h3>` with no `<h2>` in between.

- **big-sur** — 7 section headings (Overview, Places Slept, Mental Condition, Physical Condition, Meals, Leisure Time, More Photos) promoted from `###` → `##`. The `<a name='...'>` HTML4-style anchors are left as-is (separate from this fix; #211 modernized FAQ's anchors but didn't touch other articles).
- **faq** — `### Table of Contents` and `### Questions and Answers` promoted to `##`.

Other articles use a mix of h2/h3 conventions; only the two Lighthouse-sampled pages from the audit are touched here. A site-wide heading-level pass could be a follow-up.

## Test plan

- [ ] CF Pages preview renders both pages with correct visual hierarchy (h2 should still look like a section header, just slightly different from h3 in CSS)
- [ ] Run Lighthouse on `/2018/02/21/trip-report-big-sur/` and `/faq/` on the preview, confirm `heading-order` now passes