### PR TITLE
feat(redirects): add /discord and /tiktok short URLs

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -71,6 +71,8 @@ redirects:
   instagram: https://instagram.com/adanalife_
   twitter: https://twitter.com/adanalife_
   twitch: https://twitch.tv/adanalife_
+  tiktok: https://www.tiktok.com/@adanalife
+  discord: https://discord.gg/hKvNgZrk52
   # I renamed these articles
   2018/03/05/trip-recap-central-coast: 2018/03/05/trip-report-central-coast
   2019/01/13/eleven-month-update/: 2019/01/13/post-adventure-summary

--- a/source/_redirects
+++ b/source/_redirects
@@ -12,6 +12,8 @@
 /instagram      https://instagram.com/adanalife_                             301
 /twitter        https://twitter.com/adanalife_                               301
 /twitch         https://twitch.tv/adanalife_                                 301
+/tiktok         https://www.tiktok.com/@adanalife                            301
+/discord        https://discord.gg/hKvNgZrk52                                301
 /van-tour       https://youtu.be/_own6DuEpLc                                 301
 /survey         https://forms.gle/a52NamfEfCcSP7Vc9                          301
 


### PR DESCRIPTION
## Summary

Closes out the "Short-URL aliases for socials" item from `vault/website/TODO.md`. The existing set (`/twitter`, `/instagram`, `/youtube`, `/twitch`, `/facebook`, `/fb`) is already in `_redirects`; this PR adds the two missing ones:

- **`/discord`** → `https://discord.gg/hKvNgZrk52` (server invite, no expiry)
- **`/tiktok`** → `https://www.tiktok.com/@adanalife`

Both entries land in `source/_redirects` (Cloudflare Pages) and `s3_website.yml` (legacy S3 path) per the in-file "keep this in sync" comment.

## Test plan

- [ ] On the CF Pages preview, visit `/discord` and confirm it redirects to the Discord invite
- [ ] On the preview, visit `/tiktok` and confirm it redirects to the TikTok profile
- [ ] No regressions on the existing redirects (`/twitter`, `/instagram`, etc.)