### PR TITLE
fix(layout): emit <meta name="description"> for SEO

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -8,6 +8,10 @@
     <%# add meta tags for cute link previews %>
     <% ogp_tags do |property, content| %>
       <meta property="<%= property %>" content="<%= content %>" />
+      <%# mirror og:description into a classic <meta name="description"> for SEO %>
+      <% if property == 'og:description' %>
+        <meta name="description" content="<%= content %>" />
+      <% end %>
     <% end %>
 
     <%# favicons for all of the different platforms %>


### PR DESCRIPTION
## Summary

Closes the polish-tier Lighthouse `meta-description` failure: all 4 sampled pages (`/`, `/faq/`, `/about/`, big-sur trip report) only emitted `<meta property="og:description">`. Google snippets and the classic SEO description tag use `<meta name="description">`, which was missing entirely.

The fix piggybacks on the existing `ogp_tags` loop in `layout.erb` to also emit `<meta name="description">` whenever it yields `og:description`. Zero front-matter changes — pages that already declare `ogp.og.description` now ship both meta tags.

## Coverage

| Page type | Before | After |
| --- | --- | --- |
| All 4 Lighthouse-sampled pages | ✗ | ✓ |
| Articles with `description:` in front matter (full set) | ✗ | ✓ |
| Built `index.html` files total | 0 / 289 | **228 / 289** |

The 61 pages still missing a description are auto-generated archive/tag pages (`/2018/`, `/tags/<tag>/`) and a few old articles without front-matter descriptions. Lighthouse didn't sample these; could be a follow-up to add a site-wide default in `data/ogp/og.yml`.

## Test plan

- [ ] CF Pages preview renders `<meta name="description" content="...">` in `<head>` on `/`, `/faq/`, `/about/`, `/2018/02/21/trip-report-big-sur/`
- [ ] Re-run Lighthouse against those pages on the preview, confirm `meta-description` now passes