### PR TITLE
fix(prime): refresh /prime page links + drop retired host-mode P.S.

### DIFF
--- a/source/prime.html.md.erb
+++ b/source/prime.html.md.erb
@@ -10,7 +10,7 @@ You don't have to spend any money.
 Do you have Amazon Prime?
 _That's all you need!_
 
-Simply [connect your Amazon account](https://help.twitch.tv/s/article/twitch-prime-guide#HowtoSubscribetoTwitchPrime) to your Twitch account, then [subscribe for free using Twitch Prime](https://subs.twitch.tv/adanalife_).
+Simply [connect your Amazon account](https://www.twitch.tv/p/en/prime/) to your Twitch account, then [subscribe for free using Twitch Prime](https://subs.twitch.tv/adanalife_).
 You get some bonuses (including no ads and `!bonusmiles`), plus the channel gets a couple bucks.
 It's win-win, and you can do it again next month.
 <%= mn("Or support a different channel!") %>
@@ -19,11 +19,9 @@ It's win-win, and you can do it again next month.
 If you don't want to read:
 
 <% iframe_wrapper do %>
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/-KOsTHSLN9Y?rel=0&amp;controls=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/ZiIzWE_Pob0?rel=0&amp;controls=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 <% end %>
 
 Thanks for your support!
 
 -Dana
-
-P.S. Want another easy way to support the channel? [Set up an auto-host!](https://help.twitch.tv/s/article/how-to-use-host-mode#HowtoUseAutoHost)


### PR DESCRIPTION
## Summary

`/prime` had three stale references flagged in the pre-launch QA audit. Keeping the page (Twitch Prime is a major potential income source for the project) but refreshing the rotted bits:

- **YouTube embed** `-KOsTHSLN9Y` was deleted ("Video unavailable"). Swapped for [`ZiIzWE_Pob0`](https://www.youtube.com/watch?v=ZiIzWE_Pob0) ("How to Sub with Prime on Twitch", Mar 2025), which walks through the modern flow.
- **Twitch Prime guide link** `help.twitch.tv/s/article/twitch-prime-guide` 503s. Repointed to [`twitch.tv/p/en/prime/`](https://www.twitch.tv/p/en/prime/) — Twitch's official Prime landing page.
- **Auto-host P.S.** dropped — Twitch [retired host mode](https://help.twitch.tv/s/article/how-to-use-host-mode) in October 2022.

The `subs.twitch.tv/adanalife_` subscribe link still works and is unchanged.

## Test plan

- [ ] Visit `/prime` on the CF Pages preview, confirm:
  - YouTube embed loads and is playable
  - "connect your Amazon account" link goes to twitch.tv/p/en/prime/
  - "subscribe for free using Twitch Prime" link still goes to subs.twitch.tv/adanalife_
  - No P.S. about auto-host