### PR TITLE
ci: action-version hygiene sweep

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: run-linters
-        uses: super-linter/super-linter@v8.6.0
+        uses: super-linter/super-linter@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # don't post a "Super-linter summary" comment on every PR run

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -15,6 +15,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.CI_PERSONAL_ACCESS_TOKEN }}
       - name: Automatic Update
-        uses: ankitvgupta/pr-updater@v1.4.0
+        uses: ankitvgupta/pr-updater@v1.4.1
         env:
           GITHUB_TOKEN: ${{ secrets.CI_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump pinned action versions in `.github/workflows/` to current floating-major tags where available.
- Mirrors the sweeps in tripbot (#436) and infra (#480).

Most of the website's workflow pins were already on floating-major tags (post-#183), so this is a small sweep — just two leftover pinned-specific versions.

## Changes
| Action | Before | After | Notes |
|---|---|---|---|
| super-linter/super-linter | `@v8.6.0` | `@v8` | Float the major; matches the same change in tripbot #436 + infra #480 |
| ankitvgupta/pr-updater | `@v1.4.0` | `@v1.4.1` | Upstream has no floating `v1` tag (only legacy `1`/`1.x` shorthand tags that don't track v1.x patches), so pinned-patch bump |

## Already on floating-major (no change needed)
- `actions/checkout@v6`
- `actions/cache@v5`
- `ruby/setup-ruby@v1`
- `reviewdog/action-misspell@v1`
- `marocchino/sticky-pull-request-comment@v3`
- `anothrNick/github-tag-action@1`

## Skipped this round
- `Ilshidur/action-discord@0.4.0` — pre-1.0, no floating-major tag exists (only specific `0.x.y` tags), and `0.4.0` is current latest. Nothing to do.

## Test plan
- [ ] CI: testing.yml + staging.yml + super-linter.yml run green on this PR
- [ ] Linting workflow's super-linter step still runs (input shape unchanged from v8.6.0 to v8)
- [ ] update-pr.yml unchanged in behavior (it only fires on `/update` PR comments; patch-only bump is no-op surface)