### PR TITLE
fix: replace dead facebook.com/adanalifeblog URL with working /adanalifeunderscore

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -65,8 +65,8 @@ redirects:
   # I shared this URL with a buncha NERT members
   radio: 2017/10/11/san-francisco-emergency-radio-setup
   # for convenience
-  fb: https://www.facebook.com/adanalifeblog
-  facebook: https://www.facebook.com/adanalifeblog
+  fb: https://www.facebook.com/adanalifeunderscore
+  facebook: https://www.facebook.com/adanalifeunderscore
   youtube: https://www.youtube.com/channel/UC8Q7uFC1Xyr2ZnTWOk9Aizg
   instagram: https://instagram.com/adanalife_
   twitter: https://twitter.com/adanalife_

--- a/source/2017-11-27-thanksgiving-in-santa-barbara.html.md.erb
+++ b/source/2017-11-27-thanksgiving-in-santa-barbara.html.md.erb
@@ -73,5 +73,5 @@ I could get used to this lifestyle, and I think I will!
 <%= f 'sunset.jpg', 'sunset over Pismo Beach' %>
 
 Thanks for reading!
-If you would like to read future articles, you might want to like [my page on Facebook](https://www.facebook.com/adanalifeblog/).
+If you would like to read future articles, you might want to like [my page on Facebook](https://www.facebook.com/adanalifeunderscore/).
 

--- a/source/2018-02-14-and-we-re-off.html.md.erb
+++ b/source/2018-02-14-and-we-re-off.html.md.erb
@@ -48,5 +48,5 @@ I'll take lots of pictures though.
 
 I want to end this by thanking you for taking the time to read this.
 It actually makes a huge impact that there are people out there who care about me and want to see me succeed.
-If you'd like to interact with me or just stay current with my updates, be sure to "like" [my Facebook page](https://www.facebook.com/adanalifeblog/).
+If you'd like to interact with me or just stay current with my updates, be sure to "like" [my Facebook page](https://www.facebook.com/adanalifeunderscore/).
 

--- a/source/2018-02-21-trip-report-big-sur.html.md.erb
+++ b/source/2018-02-21-trip-report-big-sur.html.md.erb
@@ -182,5 +182,5 @@ You can click into any of these images to get super high resolution versions.
 <%= f 'van-on-1.jpg', 'My van on Highway 1' %>
 
 Thank you for reading this and looking at my pictures!
-If you'd like to interact with me or just stay current with my updates, don't forget to [follow my Facebook page](https://www.facebook.com/adanalifeblog/).
+If you'd like to interact with me or just stay current with my updates, don't forget to [follow my Facebook page](https://www.facebook.com/adanalifeunderscore/).
 

--- a/source/2018-03-05-trip-report-central-coast.html.md.erb
+++ b/source/2018-03-05-trip-report-central-coast.html.md.erb
@@ -97,7 +97,7 @@ I spent only one day exploring... I went down to the water and walked around dow
 <%= ff 'el-camini-cielo-pano.JPG', 'The view of Santa Barbara from the mountains' %>
 
 Thank you for reading this and looking at my pictures.
-As a reminder, if you'd like to interact with me or just stay current with my updates, you can [follow my Facebook page](https://www.facebook.com/adanalifeblog/).
+As a reminder, if you'd like to interact with me or just stay current with my updates, you can [follow my Facebook page](https://www.facebook.com/adanalifeunderscore/).
 
 I'll see you in Los Angeles!
 

--- a/source/2018-03-13-trip-report-los-angeles.html.md.erb
+++ b/source/2018-03-13-trip-report-los-angeles.html.md.erb
@@ -92,5 +92,5 @@ And it's right there for you to visit!
 
 Thank you for reading!
 I really appreciate you taking the time out of your day to visit my site.
-If you'd like to interact with me or just stay current with my updates, I'd love it if you'd "like" [my Facebook page](https://www.facebook.com/adanalifeblog/).
+If you'd like to interact with me or just stay current with my updates, I'd love it if you'd "like" [my Facebook page](https://www.facebook.com/adanalifeunderscore/).
 

--- a/source/2018-03-20-trip-report-san-diego.html.md.erb
+++ b/source/2018-03-20-trip-report-san-diego.html.md.erb
@@ -88,7 +88,7 @@ I spent two days there (one at the Zoo and one at the Safari Park), and took cou
 <%= ff 'safari-park-pano.JPG', 'The San Diego Safari Park' %>
 
 As always, thank you for visiting and looking at my pictures.
-Come visit [my Facebook page](https://www.facebook.com/adanalifeblog/) and let me know which pictures were your favorites!
+Come visit [my Facebook page](https://www.facebook.com/adanalifeunderscore/) and let me know which pictures were your favorites!
 
 <%# TODO: this is messy, but I couldn't get a link to work %>
 <figure><a href="/2018/03/20/trip-report-san-diego/salk-distant-me.JPG" class="no-underline"><img src="/2018/03/20/trip-report-san-diego/salk-distant-me.JPG" alt="Dana at the Salk Institute"></a>📸 by <a href='https://www.instagram.com/mndhm'>@mndhm</a></figure>

--- a/source/2018-03-25-trip-report-joshua-tree.html.md.erb
+++ b/source/2018-03-25-trip-report-joshua-tree.html.md.erb
@@ -125,5 +125,5 @@ Pictures don't really do it any justice, but I've done my best to include a sele
 
 Thank you for reading!
 I really appreciate you taking the time out of your day to visit my site.
-If you'd like to interact with me or just stay current with my updates, I'd love it if you'd [follow me on social media](https://www.facebook.com/adanalifeblog/).
+If you'd like to interact with me or just stay current with my updates, I'd love it if you'd [follow me on social media](https://www.facebook.com/adanalifeunderscore/).
 

--- a/source/2018-06-30-map-adventure-so-far.html.md.erb
+++ b/source/2018-06-30-map-adventure-so-far.html.md.erb
@@ -19,4 +19,4 @@ Just wanted to post a quick update showing where I've gone so far:
 
 <%= f 'map.png', 'a map showing the journey so far' %>
 
-For (slightly) more frequent updates and bonus content, [follow me on social media](https://www.facebook.com/adanalifeblog/).
+For (slightly) more frequent updates and bonus content, [follow me on social media](https://www.facebook.com/adanalifeunderscore/).

--- a/source/2018-09-26-map-adventure-so-far-v2.html.md.erb
+++ b/source/2018-09-26-map-adventure-so-far-v2.html.md.erb
@@ -22,4 +22,4 @@ When this map was created I was outside of Dallas, TX, having come from the East
 There's one last leg this map is missing... from Texas to Los Angeles, and then from LA to San Francisco (where I sold the van).
 I plan on making a better, more complete, and ideally interactive map in the future.
 
-For (slightly) more frequent updates and bonus content, you might wish to check out my [Instagram](https://instagram.com/adanalife_)/[FB](https://www.facebook.com/adanalifeblog/)/[Twitter](https://twitter.com/adanalife_).
+For (slightly) more frequent updates and bonus content, you might wish to check out my [Instagram](https://instagram.com/adanalife_)/[FB](https://www.facebook.com/adanalifeunderscore/)/[Twitter](https://twitter.com/adanalife_).

--- a/source/2019-01-13-post-adventure-summary.html.md.erb
+++ b/source/2019-01-13-post-adventure-summary.html.md.erb
@@ -66,7 +66,7 @@ Oh, one more thing!
 I recently created social media accounts on each of the major platforms, including the oft-requested Instagram, so pick your favorites and follow along:
 
 * [Instagram](https://instagram.com/adanalife_) **(by popular demand!)**
-* [Facebook](https://www.facebook.com/adanalifeblog)
+* [Facebook](https://www.facebook.com/adanalifeunderscore)
 * [Twitch](https://twitch.tv/adanalife_)
 * [Twitter](https://twitter.com/adanalife_)
 * [YouTube](/youtube)

--- a/source/_redirects
+++ b/source/_redirects
@@ -6,8 +6,8 @@
 
 # Convenience short URLs
 /radio          /2017/10/11/san-francisco-emergency-radio-setup/             301
-/fb             https://www.facebook.com/adanalifeblog                       301
-/facebook       https://www.facebook.com/adanalifeblog                       301
+/fb             https://www.facebook.com/adanalifeunderscore                       301
+/facebook       https://www.facebook.com/adanalifeunderscore                       301
 /youtube        https://www.youtube.com/channel/UC8Q7uFC1Xyr2ZnTWOk9Aizg     301
 /instagram      https://instagram.com/adanalife_                             301
 /twitter        https://twitter.com/adanalife_                               301

--- a/source/article-template.html.md.erb
+++ b/source/article-template.html.md.erb
@@ -31,7 +31,7 @@ ogp:
 
 Thank you for reading!
 I really appreciate you taking the time out of your day to visit my site.
-If you'd like to interact with me or just stay current with my updates, I'd love it if you'd [follow me on social media](https://www.facebook.com/adanalifeblog/).
+If you'd like to interact with me or just stay current with my updates, I'd love it if you'd [follow me on social media](https://www.facebook.com/adanalifeunderscore/).
 
 ### TODO List
 * add alttexts to all images

--- a/source/contact.html.md.erb
+++ b/source/contact.html.md.erb
@@ -9,7 +9,7 @@ ogp:
 
 You can find me on the following sites and contact me through there.
 
- * [Facebook](https://www.facebook.com/adanalifeblog)
+ * [Facebook](https://www.facebook.com/adanalifeunderscore)
  * [Twitter](https://twitter.com/adanalife_)
  * [Instagram](https://instagram.com/adanalife_)
  * [Twitch](https://twitch.tv/adanalife_)


### PR DESCRIPTION
## Why

The Facebook Page URL `facebook.com/adanalifeblog` (canonical per the project history) currently returns "This content isn't available right now" to logged-out visitors — discovered during a social-media audit. The page itself still exists; only the canonical URL stopped resolving externally. The `/adanalifeunderscore` alias still works and is now the right URL to publish.

## What

Find/replace `facebook.com/adanalifeblog` → `facebook.com/adanalifeunderscore` across:

- `source/_redirects` — the live CF Pages short URLs `/fb` and `/facebook`
- `s3_website.yml` — legacy s3-deploy redirects (dormant since the CF Pages migration, fixed for parity in case the file is ever reactivated)
- 10 blog posts (2017–2019) with FB call-to-action links
- 2 templates (`article-template.html.md.erb`, `contact.html.md.erb`)

No content rewrites — pure URL replacement, 16 lines changed.

## Test

- `dana.lol/fb` and `dana.lol/facebook` now redirect to the working FB URL after deploy
- Old blog posts' Facebook CTAs land on a real page instead of "content not available"

## Adjacent work

A parallel infra PR will fix the same FB URL in the `infra/terraform/{prod-1,stage-1}/static.tf` commented redirect blocks (so when those redirects ship, they ship correct).

The matching `/adanalifeunderscore` change is the new canonical handle going forward; the project's branding ADR was also updated to reflect this.